### PR TITLE
pass device to load, respect gradio share flag

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,7 +40,7 @@ print(f"Using device: {device}")
 print("Loading Nari model...")
 try:
     # Use the function from inference.py
-    model = Dia.from_pretrained("nari-labs/Dia-1.6B")
+    model = Dia.from_pretrained("nari-labs/Dia-1.6B", device=device)
 except Exception as e:
     print(f"Error loading Nari model: {e}")
     raise
@@ -387,4 +387,4 @@ with gr.Blocks(css=css) as demo:
 # --- Launch the App ---
 if __name__ == "__main__":
     print("Launching Gradio interface...")
-    demo.launch(share=True)
+    demo.launch(share=args.share)


### PR DESCRIPTION
I explicitly passed the `device` parameter to `from_pretrained`, enabling successful loading and execution on MPS (M2 max).
I passed the share flag from args to launch to avoid unnecessary creation of a tunnel.