### PR TITLE
Update app.py - Fix for "trying to convert audio automatically from float32 to 16-bit int format."

### DIFF
--- a/app.py
+++ b/app.py
@@ -192,6 +192,13 @@ def run_inference(
                 f"Audio conversion successful. Final shape: {output_audio[1].shape}, Sample Rate: {output_sr}"
             )
 
+            # Explicitly convert to int16 to prevent Gradio warning
+            if output_audio[1].dtype == np.float32 or output_audio[1].dtype == np.float64:
+                audio_for_gradio = np.clip(output_audio[1], -1.0, 1.0)
+                audio_for_gradio = (audio_for_gradio * 32767).astype(np.int16)
+                output_audio = (output_sr, audio_for_gradio)
+                print("Converted audio to int16 for Gradio output.")        
+
         else:
             print("\nGeneration finished, but no valid tokens were produced.")
             # Return default silence


### PR DESCRIPTION
This PR resolves the Gradio runtime warning:
Trying to convert audio automatically from float32 to 16-bit int format.

This error warning would appear when generating -
/app/venv/lib/python3.10/site-packages/gradio/processing_utils.py:749: UserWarning: Trying to convert audio automatically from float32 to 16-bit int format.
  warnings.warn(warning.format(data.dtype))

Details:
Explicitly converts generated audio output from float32/float64 to int16 before returning it to Gradio in the run_inference function. Ensures audio is clipped to the valid range and properly formatted for Gradio, preventing automatic type conversion and associated warnings. Improves log clarity and prevents potential downstream issues with audio playback or export.

Testing:
Verified that the warning no longer appears in the logs. Audio output remains correct and is now always int16 as expected by Gradio.

Additional:
No changes to model output or inference logic.