### PR TITLE
Update layers.py - Error Float16 key.dtype: float and value.dtype: float instead

### DIFF
--- a/dia/layers.py
+++ b/dia/layers.py
@@ -389,6 +389,9 @@ class Attention(nn.Module):
                     new_kv_cache = Xk_BxNxSxH, Xv_BxNxSxH
                     attn_k, attn_v = cache.get_kv_for_attention(Xk_BxNxSxH, Xv_BxNxSxH)
 
+        target_dtype = Xq_BxNxTxH.dtype
+        attn_k = attn_k.to(target_dtype)    
+        attn_v = attn_v.to(target_dtype)
         attn_output = F.scaled_dot_product_attention(
             Xq_BxNxTxH,
             attn_k,


### PR DESCRIPTION
Updated Attention.forward in layers.py to cast attn_k and attn_v to the same dtype as Xq_BxNxTxH (the query tensor) before the attention computation, let cpu-torch user to run the project.

Error during inference: Expected query, key, and value to have the same dtype, but got query.dtype: c10::BFloat16 key.dtype: float and value.dtype: float instead.