### PR TITLE
Update app.py - Fix for inference failure when using cpu only

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,11 @@ print("Loading Nari model...")
 try:
     # Use the function from inference.py
     model = Dia.from_pretrained("nari-labs/Dia-1.6B", device=device)
+    
+    # Ensure model's internal torch model is float32 on CPU to avoid dtype mismatch errors
+    if device.type == "cpu":
+        model.model.to(torch.float32)
+
 except Exception as e:
     print(f"Error loading Nari model: {e}")
     raise


### PR DESCRIPTION
Update to fix the following error that would occur when generating using cpu only

/app/venv/lib/python3.10/site-packages/torch/nn/utils/weight_norm.py:143: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.
  WeightNorm.apply(module, name, dim)
Launching Gradio interface...
* Running on local URL:  http://0.0.0.0:7860

To create a public link, set `share=True` in `launch()`. Error during inference: Expected query, key, and value to have the same dtype, but got query.dtype: c10::BFloat16 key.dtype: float and value.dtype: float instead. Traceback (most recent call last):
  File "/app/app.py", line 143, in run_inference
    output_audio_np = model.generate(
  File "/app/venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/app/dia/model.py", line 374, in generate
    logits_Bx1xCxV, new_cache = decode_step(
  File "/app/dia/layers.py", line 743, in decode_step
    x, new_kv_cache = layer(
  File "/app/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/app/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
  File "/app/dia/layers.py", line 605, in forward
    sa_out, new_kv_cache = self.self_attention(
  File "/app/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/app/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
  File "/app/dia/layers.py", line 392, in forward
    attn_output = F.scaled_dot_product_attention(
RuntimeError: Expected query, key, and value to have the same dtype, but got query.dtype: c10::BFloat16 key.dtype: float and value.dtype: float instead. Traceback (most recent call last):
  File "/app/app.py", line 143, in run_inference
    output_audio_np = model.generate(
  File "/app/venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/app/dia/model.py", line 374, in generate
    logits_Bx1xCxV, new_cache = decode_step(
  File "/app/dia/layers.py", line 743, in decode_step
    x, new_kv_cache = layer(
  File "/app/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/app/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
  File "/app/dia/layers.py", line 605, in forward
    sa_out, new_kv_cache = self.self_attention(
  File "/app/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/app/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
  File "/app/dia/layers.py", line 392, in forward
    attn_output = F.scaled_dot_product_attention(
RuntimeError: Expected query, key, and value to have the same dtype, but got query.dtype: c10::BFloat16 key.dtype: float and value.dtype: float instead.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/venv/lib/python3.10/site-packages/gradio/queueing.py", line 625, in process_events
    response = await route_utils.call_process_api(
  File "/app/venv/lib/python3.10/site-packages/gradio/route_utils.py", line 322, in call_process_api
    output = await app.get_blocks().process_api(
  File "/app/venv/lib/python3.10/site-packages/gradio/blocks.py", line 2136, in process_api
    result = await self.call_function(
  File "/app/venv/lib/python3.10/site-packages/gradio/blocks.py", line 1662, in call_function
    prediction = await anyio.to_thread.run_sync(  # type: ignore
  File "/app/venv/lib/python3.10/site-packages/anyio/to_thread.py", line 56, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
  File "/app/venv/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 2470, in run_sync_in_worker_thread
    return await future
  File "/app/venv/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 967, in run
    result = context.run(func, *args)
  File "/app/venv/lib/python3.10/site-packages/gradio/utils.py", line 883, in wrapper
    response = f(*args, **kwargs)
  File "/app/app.py", line 212, in run_inference
    raise gr.Error(f"Inference failed: {e}")
gradio.exceptions.Error: 'Inference failed: Expected query, key, and value to have the same dtype, but got query.dtype: c10::BFloat16 key.dtype: float and value.dtype: float instead.'