### PR TITLE
Improve Hugging Face integration (safetensors)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ You can keep speaker consistency by either adding an audio prompt (a guide comin
 
 - Generate dialogue via `[S1]` and `[S2]` tag
 - Generate non-verbal like `(laughs)`, `(coughs)`, etc.
+  - Below verbal tags will be recognized, but might result in unexpected output.
+  - `(laughs), (clears throat), (sighs), (gasps), (coughs), (singing), (sings), (mumbles), (beep), (groans), (sniffs), (claps), (screams), (inhales), (exhales), (applause), (burps), (humming), (sneezes), (chuckle), (whistles)`
 - Voice cloning. See [`example/voice_clone.py`](example/voice_clone.py) for more information.
   - In the Hugging Face space, you can upload the audio you want to clone and place its transcript before your script. Make sure the transcript follows the required format. The model will then output only the content of your script.
 

--- a/dia/layers.py
+++ b/dia/layers.py
@@ -7,7 +7,6 @@ from torch import Tensor
 from torch.nn import RMSNorm
 
 from huggingface_hub import PyTorchModelHubMixin
-from pydantic import BaseModel
 
 from .config import DiaConfig
 
@@ -831,18 +830,19 @@ class Decoder(nn.Module):
         return logits_BxTxCxV.to(torch.float32)
 
 
-class DiaModel(nn.Module,
-               PyTorchModelHubMixin,
-               repo_url="https://github.com/nari-labs/dia",
-               pipeline_tag="text-to-speech",
-               license="apache-2.0",
-               coders={
-                DiaConfig: (
-                    lambda x: x.dict(),
-                    lambda data: DiaConfig.model_validate(**data),
-                ),
-            },
-    ):
+class DiaModel(
+    nn.Module,
+    PyTorchModelHubMixin,
+    repo_url="https://github.com/nari-labs/dia",
+    pipeline_tag="text-to-speech",
+    license="apache-2.0",
+    coders={
+        DiaConfig: (
+            lambda x: x.dict(),
+            lambda data: DiaConfig.model_validate(**data),
+        ),
+    },
+):
     """PyTorch Dia Model using DenseGeneral."""
 
     def __init__(self, config: DiaConfig):

--- a/dia/layers.py
+++ b/dia/layers.py
@@ -6,6 +6,9 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import RMSNorm
 
+from huggingface_hub import PyTorchModelHubMixin
+from pydantic import BaseModel
+
 from .config import DiaConfig
 
 
@@ -828,7 +831,18 @@ class Decoder(nn.Module):
         return logits_BxTxCxV.to(torch.float32)
 
 
-class DiaModel(nn.Module):
+class DiaModel(nn.Module,
+               PyTorchModelHubMixin,
+               repo_url="https://github.com/nari-labs/dia",
+               pipeline_tag="text-to-speech",
+               license="apache-2.0",
+               coders={
+                DiaConfig: (
+                    lambda x: x.dict(),
+                    lambda data: DiaConfig.model_validate(**data),
+                ),
+            },
+    ):
     """PyTorch Dia Model using DenseGeneral."""
 
     def __init__(self, config: DiaConfig):

--- a/dia/model.py
+++ b/dia/model.py
@@ -73,65 +73,6 @@ class Dia:
         self.model = DiaModel(config)
         self.dac_model = None
 
-    @classmethod
-    def from_local(cls, config_path: str, checkpoint_path: str, device: torch.device | None = None) -> "Dia":
-        """Loads the Dia model from local configuration and checkpoint files.
-
-        Args:
-            config_path: Path to the configuration JSON file.
-            checkpoint_path: Path to the model checkpoint (.pth) file.
-            device: The device to load the model onto. If None, will automatically select the best available device.
-
-        Returns:
-            An instance of the Dia model loaded with weights and set to eval mode.
-
-        Raises:
-            FileNotFoundError: If the config or checkpoint file is not found.
-            RuntimeError: If there is an error loading the checkpoint.
-        """
-        config = DiaConfig.load(config_path)
-        if config is None:
-            raise FileNotFoundError(f"Config file not found at {config_path}")
-
-        dia = cls(config, device)
-
-        try:
-            state_dict = torch.load(checkpoint_path, map_location=dia.device)
-            dia.model.load_state_dict(state_dict)
-        except FileNotFoundError:
-            raise FileNotFoundError(f"Checkpoint file not found at {checkpoint_path}")
-        except Exception as e:
-            raise RuntimeError(f"Error loading checkpoint from {checkpoint_path}") from e
-
-        dia.model.to(dia.device)
-        dia.model.eval()
-        dia._load_dac_model()
-        return dia
-
-    @classmethod
-    def from_pretrained(
-        cls, model_name: str = "nari-labs/Dia-1.6B", device: torch.device | None = None
-    ) -> "Dia":
-        """Loads the Dia model from a Hugging Face Hub repository.
-
-        Downloads the configuration and checkpoint files from the specified
-        repository ID and then loads the model.
-
-        Args:
-            model_name: The Hugging Face Hub repository ID (e.g., "NariLabs/Dia-1.6B").
-            device: The device to load the model onto. If None, will automatically select the best available device.
-
-        Returns:
-            An instance of the Dia model loaded with weights and set to eval mode.
-
-        Raises:
-            FileNotFoundError: If config or checkpoint download/loading fails.
-            RuntimeError: If there is an error loading the checkpoint.
-        """
-        config_path = hf_hub_download(repo_id=model_name, filename="config.json")
-        checkpoint_path = hf_hub_download(repo_id=model_name, filename="dia-v0_1.pth")
-        return cls.from_local(config_path, checkpoint_path, device)
-
     def _load_dac_model(self):
         try:
             dac_model_path = dac.utils.download()

--- a/dia/model.py
+++ b/dia/model.py
@@ -109,9 +109,7 @@ class Dia:
         return dia
 
     @classmethod
-    def from_pretrained(
-        cls, model_name: str = "nari-labs/Dia-1.6B", device: torch.device | None = None
-    ) -> "Dia":
+    def from_pretrained(cls, model_name: str = "nari-labs/Dia-1.6B", device: torch.device | None = None) -> "Dia":
         """Loads the Dia model from a Hugging Face Hub repository.
 
         Downloads the configuration and checkpoint files from the specified

--- a/dia/model.py
+++ b/dia/model.py
@@ -76,12 +76,15 @@ class Dia:
     @classmethod
     def from_local(cls, config_path: str, checkpoint_path: str, device: torch.device | None = None) -> "Dia":
         """Loads the Dia model from local configuration and checkpoint files.
+
         Args:
             config_path: Path to the configuration JSON file.
             checkpoint_path: Path to the model checkpoint (.pth) file.
             device: The device to load the model onto. If None, will automatically select the best available device.
+
         Returns:
             An instance of the Dia model loaded with weights and set to eval mode.
+
         Raises:
             FileNotFoundError: If the config or checkpoint file is not found.
             RuntimeError: If there is an error loading the checkpoint.
@@ -110,13 +113,17 @@ class Dia:
         cls, model_name: str = "nari-labs/Dia-1.6B", device: torch.device | None = None
     ) -> "Dia":
         """Loads the Dia model from a Hugging Face Hub repository.
+
         Downloads the configuration and checkpoint files from the specified
         repository ID and then loads the model.
+
         Args:
             model_name: The Hugging Face Hub repository ID (e.g., "NariLabs/Dia-1.6B").
             device: The device to load the model onto. If None, will automatically select the best available device.
+
         Returns:
             An instance of the Dia model loaded with weights and set to eval mode.
+
         Raises:
             FileNotFoundError: If config or checkpoint download/loading fails.
             RuntimeError: If there is an error loading the checkpoint.
@@ -124,7 +131,7 @@ class Dia:
         config_path = hf_hub_download(repo_id=model_name, filename="config.json")
         checkpoint_path = hf_hub_download(repo_id=model_name, filename="dia-v0_1.pth")
         return cls.from_local(config_path, checkpoint_path, device)
-    
+
     def _load_dac_model(self):
         try:
             dac_model_path = dac.utils.download()

--- a/dia/model.py
+++ b/dia/model.py
@@ -73,6 +73,58 @@ class Dia:
         self.model = DiaModel(config)
         self.dac_model = None
 
+    @classmethod
+    def from_local(cls, config_path: str, checkpoint_path: str, device: torch.device | None = None) -> "Dia":
+        """Loads the Dia model from local configuration and checkpoint files.
+        Args:
+            config_path: Path to the configuration JSON file.
+            checkpoint_path: Path to the model checkpoint (.pth) file.
+            device: The device to load the model onto. If None, will automatically select the best available device.
+        Returns:
+            An instance of the Dia model loaded with weights and set to eval mode.
+        Raises:
+            FileNotFoundError: If the config or checkpoint file is not found.
+            RuntimeError: If there is an error loading the checkpoint.
+        """
+        config = DiaConfig.load(config_path)
+        if config is None:
+            raise FileNotFoundError(f"Config file not found at {config_path}")
+
+        dia = cls(config, device)
+
+        try:
+            state_dict = torch.load(checkpoint_path, map_location=dia.device)
+            dia.model.load_state_dict(state_dict)
+        except FileNotFoundError:
+            raise FileNotFoundError(f"Checkpoint file not found at {checkpoint_path}")
+        except Exception as e:
+            raise RuntimeError(f"Error loading checkpoint from {checkpoint_path}") from e
+
+        dia.model.to(dia.device)
+        dia.model.eval()
+        dia._load_dac_model()
+        return dia
+
+    @classmethod
+    def from_pretrained(
+        cls, model_name: str = "nari-labs/Dia-1.6B", device: torch.device | None = None
+    ) -> "Dia":
+        """Loads the Dia model from a Hugging Face Hub repository.
+        Downloads the configuration and checkpoint files from the specified
+        repository ID and then loads the model.
+        Args:
+            model_name: The Hugging Face Hub repository ID (e.g., "NariLabs/Dia-1.6B").
+            device: The device to load the model onto. If None, will automatically select the best available device.
+        Returns:
+            An instance of the Dia model loaded with weights and set to eval mode.
+        Raises:
+            FileNotFoundError: If config or checkpoint download/loading fails.
+            RuntimeError: If there is an error loading the checkpoint.
+        """
+        config_path = hf_hub_download(repo_id=model_name, filename="config.json")
+        checkpoint_path = hf_hub_download(repo_id=model_name, filename="dia-v0_1.pth")
+        return cls.from_local(config_path, checkpoint_path, device)
+    
     def _load_dac_model(self):
         try:
             dac_model_path = dac.utils.download()


### PR DESCRIPTION
This PR improves the integration with Hugging Face, by ensuring weights are saved in the [safetensors](https://github.com/huggingface/safetensors) format rather than the unsafer `.pth`.

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class to automatically equip the `DiaModel` class with the `from_pretrained`, `save_pretrained` and `push_to_hub` methods. Download stats also still work in that case. Calling `push_to_hub` will push a `config.json` along with `safetensors` weights to the hub.

See [here](https://colab.research.google.com/drive/15nFEac9fIN9wH4a6155U-KebL0VDNwIG?usp=sharing) for a notebook (sadly my Colab session crashes due to all available RAM being used).