### PR TITLE
Use device_map to split model

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,7 +22,7 @@ parser.add_argument(
     "--device-map", 
     type=str, 
     default="auto", 
-    choices=["auto", "balanced", "cuda", "cpu"],
+    choices=["auto", "balanced", "balanced_low_0", "sequential"],
     help="How to distribute model across devices (default: auto)"
 )
 

--- a/app.py
+++ b/app.py
@@ -18,6 +18,13 @@ parser.add_argument(
     "--device", type=str, default=None, help="Force device (e.g., 'cuda', 'mps', 'cpu')"
 )
 parser.add_argument("--share", action="store_true", help="Enable Gradio sharing")
+parser.add_argument(
+    "--device-map", 
+    type=str, 
+    default="auto", 
+    choices=["auto", "balanced", "cuda", "cpu"],
+    help="How to distribute model across devices (default: auto)"
+)
 
 args = parser.parse_args()
 
@@ -35,12 +42,13 @@ else:
     device = torch.device("cpu")
 
 print(f"Using device: {device}")
+print(f"Device map: {args.device_map}")
 
 # Load Nari model and config
 print("Loading Nari model...")
 try:
     # Use the function from inference.py
-    model = Dia.from_pretrained("nari-labs/Dia-1.6B", device=device)
+    model = Dia.from_pretrained("nari-labs/Dia-1.6B", device=device, device_map=args.device_map)
 except Exception as e:
     print(f"Error loading Nari model: {e}")
     raise

--- a/cli.py
+++ b/cli.py
@@ -73,6 +73,13 @@ def main():
         default="cuda" if torch.cuda.is_available() else "cpu",
         help="Device to run inference on (e.g., 'cuda', 'cpu', default: auto).",
     )
+    infra_group.add_argument(
+        "--device-map",
+        type=str,
+        default="auto",
+        choices=["auto", "balanced", "balanced_low_0", "sequential"],
+        help="How to distribute model across devices (default: auto).",
+    )
 
     args = parser.parse_args()
 
@@ -100,15 +107,17 @@ def main():
     print("Loading model...")
     if args.local_paths:
         print(f"Loading from local paths: config='{args.config}', checkpoint='{args.checkpoint}'")
+        print(f"Device map: {args.device_map}")
         try:
-            model = Dia.from_local(args.config, args.checkpoint, device=device)
+            model = Dia.from_local(args.config, args.checkpoint, device=device, device_map=args.device_map)
         except Exception as e:
             print(f"Error loading local model: {e}")
             exit(1)
     else:
         print(f"Loading from Hugging Face Hub: repo_id='{args.repo_id}'")
+        print(f"Device map: {args.device_map}")
         try:
-            model = Dia.from_pretrained(args.repo_id, device=device)
+            model = Dia.from_pretrained(args.repo_id, device=device, device_map=args.device_map)
         except Exception as e:
             print(f"Error loading model from Hub: {e}")
             exit(1)


### PR DESCRIPTION
Use huggingface builtin `device_map` to auto split the model. Enables users with less vram to still use the model. (e.g. on my 12GB gpu I go from OOM errors to running just fine).