### PR TITLE
Add Docker support with Dockerfile and docker-compose configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,51 @@
+# Version control
+.git
+.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Environment
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Docker
+Dockerfile*
+docker-compose.yml
+.dockerignore
+
+# IDE files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Large files that should be mounted as volumes
+data/
+*.pth
+*.pt
+*.bin
+
+# Logs
+*.log 

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -1,0 +1,37 @@
+FROM nvidia/cuda:12.6.0-runtime-ubuntu22.04
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    python3.10 \
+    python3.10-dev \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set Python 3.10 as default
+RUN ln -sf /usr/bin/python3.10 /usr/bin/python3 && \
+    ln -sf /usr/bin/python3 /usr/bin/python && \
+    ln -sf /usr/bin/pip3 /usr/bin/pip
+
+# Copy project files
+COPY . /app/
+
+# Install uv and use it for dependency management
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir uv \
+    && uv pip install --no-cache-dir -e .
+
+# Expose the Gradio port
+EXPOSE 7860
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+
+# Run the Gradio web app with uv
+CMD ["uv", "run", "app.py"] 

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,0 +1,35 @@
+FROM nvidia/cuda:12.6.0-runtime-ubuntu22.04
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    python3.10 \
+    python3.10-dev \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set Python 3.10 as default
+RUN ln -sf /usr/bin/python3.10 /usr/bin/python3 && \
+    ln -sf /usr/bin/python3 /usr/bin/python && \
+    ln -sf /usr/bin/pip3 /usr/bin/pip
+
+# Copy project files
+COPY . /app/
+
+# Install uv and use it for dependency management
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir uv \
+    && uv pip install --no-cache-dir -e .
+
+# Set the entrypoint
+ENTRYPOINT ["python", "cli.py"]
+
+# Default command (will be overridden when used with run)
+# docker-compose --profile cli run dia-cli "[S1] Hello, welcome to Dia! [S2] Thanks for trying out our text to speech model." --output /app/data/output.wav --repo-id nari-labs/Dia-1.6B
+CMD ["--help"] 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  dia-app:
+    build:
+      context: .
+      dockerfile: Dockerfile.app
+    profiles: ["app"]
+    ports:
+      - "7860:7860"
+    volumes:
+      - ./data:/app/data
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    restart: unless-stopped
+
+  dia-cli:
+    build:
+      context: .
+      dockerfile: Dockerfile.cli
+    profiles: ["cli"]
+    volumes:
+      - ./data:/app/data
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]


### PR DESCRIPTION
- Created .dockerignore to exclude unnecessary files from Docker context.
- Added Dockerfile.app for the Gradio web app with Python 3.10 and necessary dependencies.
- Added Dockerfile.cli for the command-line interface with similar setup.
- Added docker-compose.yml to manage app and CLI services with Nvidia GPU support.