### PR TITLE
Update README.md file to include instruction to set HF_TOKEN ENV variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ We also provide a [demo page](https://yummy-fir-7a4.notion.site/dia) comparing o
 pip install git+https://github.com/nari-labs/dia.git
 ```
 
+### Set HF_TOKEN ENV var
+
+```bash
+# Set the HF_TOKEN ENV var to auto download config from HF Hub
+export HF_TOKEN="your token"
+```
+
 ### Run the Gradio UI
 
 This will open a Gradio UI that you can work on.


### PR DESCRIPTION
This documentation fix solves issue - https://github.com/nari-labs/dia/issues/145

The `HF_TOKEN` ENV variable needs to be set before the `app.py` can be run.

The `config` file needs to be downloaded from the `Hugging Face Hub`. The `hf_hub_download` method here - https://github.com/tralamazza/dia/blob/optional-rocm-cuda/dia/model.py#L175 will fail without the `HF_TOKEN`

