### PR TITLE
Fix compiling with `fullgraph=True` to improve inference time.

### DIFF
--- a/dia/model.py
+++ b/dia/model.py
@@ -36,7 +36,7 @@ def _sample_next_token(
     if cfg_filter_top_k is not None:
         _, top_k_indices_BCxV = torch.topk(logits_BCxV, k=cfg_filter_top_k, dim=-1)
         mask = torch.ones_like(logits_BCxV, dtype=torch.bool)
-        mask.scatter_(dim=-1, index=top_k_indices_BCxV, value=False)
+        mask = mask.scatter(dim=-1, index=top_k_indices_BCxV, value=False)
         logits_BCxV = logits_BCxV.masked_fill(mask, -torch.inf)
 
     if top_p < 1.0:
@@ -45,11 +45,11 @@ def _sample_next_token(
         cumulative_probs_BCxV = torch.cumsum(sorted_probs_BCxV, dim=-1)
 
         sorted_indices_to_remove_BCxV = cumulative_probs_BCxV > top_p
-        sorted_indices_to_remove_BCxV[..., 1:] = sorted_indices_to_remove_BCxV[..., :-1].clone()
-        sorted_indices_to_remove_BCxV[..., 0] = 0
+        sorted_indices_to_remove_BCxV = torch.roll(sorted_indices_to_remove_BCxV, shifts=1, dims=-1)
+        sorted_indices_to_remove_BCxV[..., 0] = torch.zeros_like(sorted_indices_to_remove_BCxV[..., 0])
 
         indices_to_remove_BCxV = torch.zeros_like(sorted_indices_to_remove_BCxV)
-        indices_to_remove_BCxV.scatter_(dim=-1, index=sorted_indices_BCxV, src=sorted_indices_to_remove_BCxV)
+        indices_to_remove_BCxV = indices_to_remove_BCxV.scatter(dim=-1, index=sorted_indices_BCxV, src=sorted_indices_to_remove_BCxV)
         logits_BCxV = logits_BCxV.masked_fill(indices_to_remove_BCxV, -torch.inf)
 
     final_probs_BCxV = torch.softmax(logits_BCxV, dim=-1)
@@ -97,7 +97,7 @@ class Dia:
         if isinstance(compute_dtype, str):
             compute_dtype = ComputeDtype(compute_dtype)
         self.compute_dtype = compute_dtype.to_dtype()
-        self.model = DiaModel(config, self.compute_dtype)
+        self.model: DiaModel = DiaModel(config, self.compute_dtype)
         self.dac_model = None
 
     @classmethod
@@ -195,19 +195,17 @@ class Dia:
         text_tokens = list(replaced_bytes)
 
         current_len = len(text_tokens)
-        padding_needed = max_len - current_len
-        if padding_needed <= 0:
-            text_tokens = text_tokens[:max_len]
-            padded_text_np = np.array(text_tokens, dtype=np.uint8)
-        else:
-            padded_text_np = np.pad(
-                text_tokens,
-                (0, padding_needed),
-                mode="constant",
-                constant_values=text_pad_value,
-            ).astype(np.uint8)
-
-        src_tokens = torch.from_numpy(padded_text_np).to(torch.long).to(self.device).unsqueeze(0)  # [1, S]
+        src_tokens = torch.full(
+            (1, max_len),
+            fill_value=text_pad_value,
+            dtype=torch.long,
+            device=self.device,
+        )
+        src_tokens[0, :current_len] = torch.tensor(
+            text_tokens[:max_len],
+            dtype=torch.long,
+            device=self.device,
+        )
         return src_tokens
 
     def _prepare_audio_prompt(self, audio_prompt: torch.Tensor | None) -> tuple[torch.Tensor, int]:
@@ -217,23 +215,26 @@ class Dia:
         delay_pattern = self.config.data.delay_pattern
         max_delay_pattern = max(delay_pattern)
 
-        prefill = torch.full(
-            (1, num_channels),
-            fill_value=audio_bos_value,
-            dtype=torch.int,
-            device=self.device,
-        )
+        parts = [
+            torch.full(
+                (1, num_channels),
+                fill_value=audio_bos_value,
+                dtype=torch.int,
+                device=self.device,
+            )
+        ]
 
         prefill_step = 1
 
         if audio_prompt is not None:
             prefill_step += audio_prompt.shape[0]
-            prefill = torch.cat([prefill, audio_prompt], dim=0)
+            parts.append(audio_prompt)
 
         delay_pad_tensor = torch.full(
             (max_delay_pattern, num_channels), fill_value=-1, dtype=torch.int, device=self.device
         )
-        prefill = torch.cat([prefill, delay_pad_tensor], dim=0)
+        parts.append(delay_pad_tensor)
+        prefill = torch.cat(parts, dim=0)
 
         delay_precomp = build_delay_indices(
             B=1,
@@ -293,16 +294,21 @@ class Dia:
         audio_eos_value = self.config.data.audio_eos_value
         logits_Bx1xCxV = self.model.decoder.decode_step(tokens_Bx1xC, dec_state)
 
-        logits_last_BxCxV = logits_Bx1xCxV[:, -1, :, :]
-        uncond_logits_CxV = logits_last_BxCxV[0, :, :]
-        cond_logits_CxV = logits_last_BxCxV[1, :, :]
-
+        logits_last_BxCxV = logits_Bx1xCxV[:, -1]
+        uncond_logits_CxV = logits_last_BxCxV[0]
+        cond_logits_CxV = logits_last_BxCxV[1]
         logits_CxV = cond_logits_CxV + cfg_scale * (cond_logits_CxV - uncond_logits_CxV)
-        logits_CxV[:, audio_eos_value + 1 :] = -torch.inf
-        logits_CxV[1:, audio_eos_value:] = -torch.inf
+        logits_CxV[:, audio_eos_value + 1:] = torch.full_like(
+            logits_CxV[:, audio_eos_value + 1:],
+            fill_value=-torch.inf,
+        )
+        logits_CxV[1:, audio_eos_value:] = torch.full_like(
+            logits_CxV[1:, audio_eos_value:],
+            fill_value=-torch.inf,
+        )
 
         pred_C = _sample_next_token(
-            logits_CxV.float(),
+            logits_CxV.to(dtype=torch.float32),
             temperature=temperature,
             top_p=top_p,
             cfg_filter_top_k=cfg_filter_top_k,
@@ -384,17 +390,17 @@ class Dia:
         if verbose:
             total_start_time = time.time()
 
+        if use_torch_compile and not hasattr(self, "_compiled"):
+            # Compilation can take about a minute.
+            self._prepare_generation = torch.compile(self._prepare_generation, dynamic=True)
+            self._decoder_step = torch.compile(self._decoder_step, fullgraph=True, mode="max-autotune")
+            self._compiled = True
         dec_state, dec_output = self._prepare_generation(text, audio_prompt, verbose)
         dec_step = dec_output.prefill_step - 1
 
         bos_countdown = max_delay_pattern
         eos_detected = False
         eos_countdown = -1
-
-        if use_torch_compile:
-            step_fn = torch.compile(self._decoder_step, mode="default")
-        else:
-            step_fn = self._decoder_step
 
         if verbose:
             print("generate: starting generation loop")
@@ -403,9 +409,10 @@ class Dia:
             start_time = time.time()
 
         while dec_step < max_tokens:
+            torch.compiler.cudagraph_mark_step_begin()
             dec_state.prepare_step(dec_step)
             tokens_Bx1xC = dec_output.get_tokens_at(dec_step).unsqueeze(0).expand(2, -1, -1)
-            pred_C = step_fn(
+            pred_C = self._decoder_step(
                 tokens_Bx1xC,
                 dec_state,
                 cfg_scale,

--- a/dia/model.py
+++ b/dia/model.py
@@ -100,6 +100,9 @@ class Dia:
         self.model: DiaModel = DiaModel(config, self.compute_dtype)
         self.dac_model = None
 
+        if torch.cuda.is_available():
+            torch.backends.cuda.matmul.allow_tf32 = True
+
     @classmethod
     def from_local(
         cls,


### PR DESCRIPTION
This PR improves performance by resolving issues occurring when using `torch.compile` with `fullgraph=True`.

Other smaller optimisations include:
- Allocation then filling tensors, rather than multiple allocations then merged with a concatenation that again allocates memory. 
- Removing redundant clone/copy operation.

Future optimisations can include chunked inference. Currently in the below code, `pred_C[0] == audio_eos_value` implicitly requires a sync between CPU and GPU, as it output dependant control-flow. The effect of this can be redude by either: 
- Checking only every $n$ steps, where $n$ is the chunk size. Eg: $n=4$ would mean check every 4 steps.
- Skipping the first $n$, where $n$ is the minimum number of expected inference steps. Eg: $n=86$ would mean check only after the first 1s of generated values.

```python
if (not eos_detected and pred_C[0] == audio_eos_value) or dec_step == max_tokens - max_delay_pattern - 1:
    eos_detected = True
    eos_countdown = max_delay_pattern
```


**Before**

```txt
generate step 86: speed=176.460 tokens/s, realtime factor=2.052x
generate step 172: speed=179.140 tokens/s, realtime factor=2.083x
generate step 258: speed=178.068 tokens/s, realtime factor=2.071x
generate step 344: speed=177.850 tokens/s, realtime factor=2.068x
generate step 430: speed=177.793 tokens/s, realtime factor=2.067x
generate step 516: speed=177.898 tokens/s, realtime factor=2.069x
generate step 602: speed=177.893 tokens/s, realtime factor=2.069x
```

**After**

```txt
generate step 86: speed=196.078 tokens/s, realtime factor=2.280x
generate step 172: speed=201.137 tokens/s, realtime factor=2.339x
generate step 258: speed=200.027 tokens/s, realtime factor=2.326x
generate step 344: speed=200.779 tokens/s, realtime factor=2.335x
generate step 430: speed=200.917 tokens/s, realtime factor=2.336x
generate step 516: speed=200.252 tokens/s, realtime factor=2.329x
generate step 602: speed=199.133 tokens/s, realtime factor=2.315x
```

Benchmarks done on a 4090 @ 300W, on the text in `simple.py`

Edit: using FP16 for both.