### PR TITLE
[Perf] Adjust KV Cache for torch.compile friendly

### DIFF
--- a/dia/model.py
+++ b/dia/model.py
@@ -36,7 +36,7 @@ def _sample_next_token(
     if cfg_filter_top_k is not None:
         _, top_k_indices_BCxV = torch.topk(logits_BCxV, k=cfg_filter_top_k, dim=-1)
         mask = torch.ones_like(logits_BCxV, dtype=torch.bool)
-        mask.scatter_(dim=-1, index=top_k_indices_BCxV, value=False)
+        mask = mask.scatter(dim=-1, index=top_k_indices_BCxV, value=False)
         logits_BCxV = logits_BCxV.masked_fill(mask, -torch.inf)
 
     if top_p < 1.0:
@@ -45,11 +45,11 @@ def _sample_next_token(
         cumulative_probs_BCxV = torch.cumsum(sorted_probs_BCxV, dim=-1)
 
         sorted_indices_to_remove_BCxV = cumulative_probs_BCxV > top_p
-        sorted_indices_to_remove_BCxV[..., 1:] = sorted_indices_to_remove_BCxV[..., :-1].clone()
-        sorted_indices_to_remove_BCxV[..., 0] = 0
+        sorted_indices_to_remove_BCxV = torch.roll(sorted_indices_to_remove_BCxV, shifts=1, dims=-1)
+        sorted_indices_to_remove_BCxV[..., 0] = torch.zeros_like(sorted_indices_to_remove_BCxV[..., 0])
 
         indices_to_remove_BCxV = torch.zeros_like(sorted_indices_to_remove_BCxV)
-        indices_to_remove_BCxV.scatter_(dim=-1, index=sorted_indices_BCxV, src=sorted_indices_to_remove_BCxV)
+        indices_to_remove_BCxV = indices_to_remove_BCxV.scatter(dim=-1, index=sorted_indices_BCxV, src=sorted_indices_to_remove_BCxV)
         logits_BCxV = logits_BCxV.masked_fill(indices_to_remove_BCxV, -torch.inf)
 
     final_probs_BCxV = torch.softmax(logits_BCxV, dim=-1)
@@ -97,7 +97,7 @@ class Dia:
         if isinstance(compute_dtype, str):
             compute_dtype = ComputeDtype(compute_dtype)
         self.compute_dtype = compute_dtype.to_dtype()
-        self.model = DiaModel(config, self.compute_dtype)
+        self.model: DiaModel = DiaModel(config, self.compute_dtype)
         self.dac_model = None
 
     @classmethod
@@ -195,19 +195,17 @@ class Dia:
         text_tokens = list(replaced_bytes)
 
         current_len = len(text_tokens)
-        padding_needed = max_len - current_len
-        if padding_needed <= 0:
-            text_tokens = text_tokens[:max_len]
-            padded_text_np = np.array(text_tokens, dtype=np.uint8)
-        else:
-            padded_text_np = np.pad(
-                text_tokens,
-                (0, padding_needed),
-                mode="constant",
-                constant_values=text_pad_value,
-            ).astype(np.uint8)
-
-        src_tokens = torch.from_numpy(padded_text_np).to(torch.long).to(self.device).unsqueeze(0)  # [1, S]
+        src_tokens = torch.full(
+            (1, max_len),
+            fill_value=text_pad_value,
+            dtype=torch.long,
+            device=self.device,
+        )
+        src_tokens[0, :current_len] = torch.tensor(
+            text_tokens[:max_len],
+            dtype=torch.long,
+            device=self.device,
+        )
         return src_tokens
 
     def _prepare_audio_prompt(self, audio_prompt: torch.Tensor | None) -> tuple[torch.Tensor, int]:
@@ -217,23 +215,26 @@ class Dia:
         delay_pattern = self.config.data.delay_pattern
         max_delay_pattern = max(delay_pattern)
 
-        prefill = torch.full(
-            (1, num_channels),
-            fill_value=audio_bos_value,
-            dtype=torch.int,
-            device=self.device,
-        )
+        parts = [
+            torch.full(
+                (1, num_channels),
+                fill_value=audio_bos_value,
+                dtype=torch.int,
+                device=self.device,
+            )
+        ]
 
         prefill_step = 1
 
         if audio_prompt is not None:
             prefill_step += audio_prompt.shape[0]
-            prefill = torch.cat([prefill, audio_prompt], dim=0)
+            parts.append(audio_prompt)
 
         delay_pad_tensor = torch.full(
             (max_delay_pattern, num_channels), fill_value=-1, dtype=torch.int, device=self.device
         )
-        prefill = torch.cat([prefill, delay_pad_tensor], dim=0)
+        parts.append(delay_pad_tensor)
+        prefill = torch.cat(parts, dim=0)
 
         delay_precomp = build_delay_indices(
             B=1,
@@ -293,16 +294,21 @@ class Dia:
         audio_eos_value = self.config.data.audio_eos_value
         logits_Bx1xCxV = self.model.decoder.decode_step(tokens_Bx1xC, dec_state)
 
-        logits_last_BxCxV = logits_Bx1xCxV[:, -1, :, :]
-        uncond_logits_CxV = logits_last_BxCxV[0, :, :]
-        cond_logits_CxV = logits_last_BxCxV[1, :, :]
-
+        logits_last_BxCxV = logits_Bx1xCxV[:, -1]
+        uncond_logits_CxV = logits_last_BxCxV[0]
+        cond_logits_CxV = logits_last_BxCxV[1]
         logits_CxV = cond_logits_CxV + cfg_scale * (cond_logits_CxV - uncond_logits_CxV)
-        logits_CxV[:, audio_eos_value + 1 :] = -torch.inf
-        logits_CxV[1:, audio_eos_value:] = -torch.inf
+        logits_CxV[:, audio_eos_value + 1:] = torch.full_like(
+            logits_CxV[:, audio_eos_value + 1:],
+            fill_value=-torch.inf,
+        )
+        logits_CxV[1:, audio_eos_value:] = torch.full_like(
+            logits_CxV[1:, audio_eos_value:],
+            fill_value=-torch.inf,
+        )
 
         pred_C = _sample_next_token(
-            logits_CxV.float(),
+            logits_CxV.to(dtype=torch.float32),
             temperature=temperature,
             top_p=top_p,
             cfg_filter_top_k=cfg_filter_top_k,
@@ -384,17 +390,17 @@ class Dia:
         if verbose:
             total_start_time = time.time()
 
+        if use_torch_compile and not hasattr(self, "_compiled"):
+            # Compilation can take about a minute.
+            self._prepare_generation = torch.compile(self._prepare_generation, dynamic=True)
+            self._decoder_step = torch.compile(self._decoder_step, fullgraph=True, mode="max-autotune")
+            self._compiled = True
         dec_state, dec_output = self._prepare_generation(text, audio_prompt, verbose)
         dec_step = dec_output.prefill_step - 1
 
         bos_countdown = max_delay_pattern
         eos_detected = False
         eos_countdown = -1
-
-        if use_torch_compile:
-            step_fn = torch.compile(self._decoder_step, mode="default")
-        else:
-            step_fn = self._decoder_step
 
         if verbose:
             print("generate: starting generation loop")
@@ -403,9 +409,10 @@ class Dia:
             start_time = time.time()
 
         while dec_step < max_tokens:
+            torch.compiler.cudagraph_mark_step_begin()
             dec_state.prepare_step(dec_step)
             tokens_Bx1xC = dec_output.get_tokens_at(dec_step).unsqueeze(0).expand(2, -1, -1)
-            pred_C = step_fn(
+            pred_C = self._decoder_step(
                 tokens_Bx1xC,
                 dec_state,
                 cfg_scale,

--- a/dia/model.py
+++ b/dia/model.py
@@ -49,7 +49,9 @@ def _sample_next_token(
         sorted_indices_to_remove_BCxV[..., 0] = torch.zeros_like(sorted_indices_to_remove_BCxV[..., 0])
 
         indices_to_remove_BCxV = torch.zeros_like(sorted_indices_to_remove_BCxV)
-        indices_to_remove_BCxV = indices_to_remove_BCxV.scatter(dim=-1, index=sorted_indices_BCxV, src=sorted_indices_to_remove_BCxV)
+        indices_to_remove_BCxV = indices_to_remove_BCxV.scatter(
+            dim=-1, index=sorted_indices_BCxV, src=sorted_indices_to_remove_BCxV
+        )
         logits_BCxV = logits_BCxV.masked_fill(indices_to_remove_BCxV, -torch.inf)
 
     final_probs_BCxV = torch.softmax(logits_BCxV, dim=-1)
@@ -302,8 +304,8 @@ class Dia:
         uncond_logits_CxV = logits_last_BxCxV[0]
         cond_logits_CxV = logits_last_BxCxV[1]
         logits_CxV = cond_logits_CxV + cfg_scale * (cond_logits_CxV - uncond_logits_CxV)
-        logits_CxV[:, audio_eos_value + 1:] = torch.full_like(
-            logits_CxV[:, audio_eos_value + 1:],
+        logits_CxV[:, audio_eos_value + 1 :] = torch.full_like(
+            logits_CxV[:, audio_eos_value + 1 :],
             fill_value=-torch.inf,
         )
         logits_CxV[1:, audio_eos_value:] = torch.full_like(
@@ -426,7 +428,7 @@ class Dia:
                 cfg_filter_top_k,
                 current_idx,
             )
-            
+
             current_idx += 1
 
             if (not eos_detected and pred_C[0] == audio_eos_value) or dec_step == max_tokens - max_delay_pattern - 1:

--- a/dia/model.py
+++ b/dia/model.py
@@ -100,6 +100,9 @@ class Dia:
         self.model: DiaModel = DiaModel(config, self.compute_dtype)
         self.dac_model = None
 
+        if torch.cuda.is_available():
+            torch.backends.cuda.matmul.allow_tf32 = True
+
     @classmethod
     def from_local(
         cls,

--- a/dia/state.py
+++ b/dia/state.py
@@ -144,7 +144,7 @@ class DecoderInferenceState:
 
         dec_positions = torch.full((2, 1), fill_value=0, dtype=torch.int32, device=device)
         tgt_padding_mask = torch.ones((2, 1), dtype=torch.bool, device=device)
-        
+
         dec_cross_attn_mask = create_attn_mask(tgt_padding_mask, enc_state.padding_mask, device, is_causal=False)
         causal_mask = torch.tril(torch.ones(max_audio_len, max_audio_len, dtype=torch.bool, device=device))
 

--- a/dia/state.py
+++ b/dia/state.py
@@ -58,6 +58,7 @@ class EncoderInferenceState:
             torch.arange(config.data.text_length, dtype=torch.float32, device=device).unsqueeze(0).expand(2, -1)
         )
         padding_mask = (cond_src != config.data.text_pad_value).to(device).expand(2, -1)
+
         attn_mask = create_attn_mask(padding_mask, padding_mask, device, is_causal=False)
 
         return cls(
@@ -69,7 +70,7 @@ class EncoderInferenceState:
         )
 
 
-class KVCache:
+class KVCache(torch.nn.Module):
     def __init__(
         self,
         num_heads: int,
@@ -80,9 +81,12 @@ class KVCache:
         k: torch.Tensor | None = None,
         v: torch.Tensor | None = None,
     ):
-        self.k = torch.zeros((2, num_heads, max_len, head_dim), dtype=dtype, device=device) if k is None else k
-        self.v = torch.zeros((2, num_heads, max_len, head_dim), dtype=dtype, device=device) if v is None else v
-        self.current_idx = 0
+        k = torch.zeros((2, num_heads, max_len, head_dim), dtype=dtype, device=device) if k is None else k
+        v = torch.zeros((2, num_heads, max_len, head_dim), dtype=dtype, device=device) if v is None else v
+
+        super().__init__()
+        self.register_buffer("k", k)
+        self.register_buffer("v", v)
 
     @classmethod
     def from_kv(cls, k: torch.Tensor, v: torch.Tensor) -> "KVCache":
@@ -96,11 +100,13 @@ class KVCache:
             v=v,
         )
 
-    def update(self, k: torch.Tensor, v: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        self.k[:, :, self.current_idx : self.current_idx + 1, :] = k
-        self.v[:, :, self.current_idx : self.current_idx + 1, :] = v
-        self.current_idx += 1
-        return self.k[:, :, : self.current_idx, :], self.v[:, :, : self.current_idx, :]
+    def update(self, k: torch.Tensor, v: torch.Tensor, current_idx: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        k_out, v_out = self.k, self.v
+        k_out[:, :, current_idx, :] = k
+        v_out[:, :, current_idx, :] = v
+        # self.current_idx += 1
+        # return self.k[:, :, : self.current_idx, :], self.v[:, :, : self.current_idx, :]
+        return self.k, self.v
 
     def prefill(self, k: torch.Tensor, v: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         prefill_len = k.shape[2]
@@ -121,6 +127,7 @@ class DecoderInferenceState:
     dec_cross_attn_mask: torch.Tensor
     self_attn_cache: list[KVCache]
     cross_attn_cache: list[KVCache]
+    casual_attn_mask: torch.Tensor
 
     @classmethod
     def new(
@@ -137,7 +144,9 @@ class DecoderInferenceState:
 
         dec_positions = torch.full((2, 1), fill_value=0, dtype=torch.int32, device=device)
         tgt_padding_mask = torch.ones((2, 1), dtype=torch.bool, device=device)
+        
         dec_cross_attn_mask = create_attn_mask(tgt_padding_mask, enc_state.padding_mask, device, is_causal=False)
+        causal_mask = torch.tril(torch.ones(max_audio_len, max_audio_len, dtype=torch.bool, device=device))
 
         self_attn_cache = [
             KVCache(
@@ -159,6 +168,7 @@ class DecoderInferenceState:
             dec_cross_attn_mask=dec_cross_attn_mask,
             self_attn_cache=self_attn_cache,
             cross_attn_cache=dec_cross_attn_cache,
+            casual_attn_mask=causal_mask,
         )
 
     def prepare_step(self, step_from: int, step_to: int | None = None) -> None:

--- a/example/benchmark.py
+++ b/example/benchmark.py
@@ -1,7 +1,8 @@
 from random import choice
-from dia.model import Dia
 
 import torch
+
+from dia.model import Dia
 
 
 torch._inductor.config.coordinate_descent_tuning = True
@@ -34,4 +35,3 @@ for _ in range(2):
 for _ in range(10):
     text = choice(test_cases)
     output = model.generate(text, use_torch_compile=True, verbose=True)
-

--- a/example/benchmark.py
+++ b/example/benchmark.py
@@ -1,0 +1,37 @@
+from random import choice
+from dia.model import Dia
+
+import torch
+
+
+torch._inductor.config.coordinate_descent_tuning = True
+torch._inductor.config.triton.unique_kernel_names = True
+torch._inductor.config.fx_graph_cache = True
+
+# debugging
+torch._logging.set_logs(graph_breaks=True, recompiles=True)
+
+model_name = "nari-labs/Dia-1.6B"
+compute_dtype = "float16"
+
+model = Dia.from_pretrained(model_name, compute_dtype=compute_dtype)
+
+
+test_cases = [
+    "[S1] Dia is an open weights text to dialogue model.",
+    "[S1] Dia is an open weights text to dialogue model. [S2] You get full control over scripts and voices. [S1] Wow. Amazing. (laughs) [S2] Try it now on Git hub or Hugging Face.",
+    "[S1] torch.compile is a new feature in PyTorch that allows you to compile your model with a single line of code.",
+    "[S1] torch.compile is a new feature in PyTorch that allows you to compile your model with a single line of code. [S2] It is a new feature in PyTorch that allows you to compile your model with a single line of code.",
+]
+
+
+# Wram up
+for _ in range(2):
+    text = choice(test_cases)
+    output = model.generate(text, use_torch_compile=True, verbose=True)
+
+# Benchmark
+for _ in range(10):
+    text = choice(test_cases)
+    output = model.generate(text, use_torch_compile=True, verbose=True)
+


### PR DESCRIPTION
Build on top of: https://github.com/nari-labs/dia/pull/162

- Adjust KVCache like gpt-fast style:
    - Using a outside current_index tensor instead of a class attribute which cause: skipping cudagraphs due to mutated inputs (36 instances)
- Add benchmark script

Result:
A100:
```
generate step 86: speed=103.650 tokens/s, realtime factor=1.205x
generate step 172: speed=192.087 tokens/s, realtime factor=2.234x
generate step 258: speed=191.480 tokens/s, realtime factor=2.227x
generate step 344: speed=192.203 tokens/s, realtime factor=2.235x
generate step 430: speed=192.052 tokens/s, realtime factor=2.233x
```

4090:
```
generate step 86: speed=78.049 tokens/s, realtime factor=0.908x
generate step 172: speed=197.427 tokens/s, realtime factor=2.296x
generate step 258: speed=197.933 tokens/s, realtime factor=2.302x
generate step 344: speed=197.997 tokens/s, realtime factor=2.302x
generate step 430: speed=197.914 tokens/s, realtime factor=2.301x
generate step 516: speed=197.846 tokens/s, realtime factor=2.301x
generate step 602: speed=197.875 tokens/s, realtime factor=2.301x
generate step 688: speed=197.797 tokens/s, realtime factor=2.300x
```