### PR TITLE
Reduce recompilation of `_prepare_generation` through more graph break fixes.

### DIFF
--- a/dia/model.py
+++ b/dia/model.py
@@ -190,14 +190,23 @@ class Dia:
             raise RuntimeError("Failed to load DAC model") from e
         self.dac_model = dac_model
 
-    def _prepare_text_input(self, text: str) -> torch.Tensor:
-        """Encodes text prompt, pads, and creates attention mask and positions."""
-        text_pad_value = self.config.data.text_pad_value
+    def _encode_text(self, text: str) -> torch.Tensor:
+        """Encodes the input text into a tensor of token IDs."""
         max_len = self.config.data.text_length
 
         byte_text = text.encode("utf-8")
         replaced_bytes = byte_text.replace(b"[S1]", b"\x01").replace(b"[S2]", b"\x02")
         text_tokens = list(replaced_bytes)
+        return torch.tensor(
+            text_tokens[:max_len],
+            dtype=torch.long,
+            device=self.device,
+        )
+
+    def _pad_text_input(self, text_tokens: torch.Tensor) -> torch.Tensor:
+        """Pads the text input to the maximum length."""
+        text_pad_value = self.config.data.text_pad_value
+        max_len = self.config.data.text_length
 
         current_len = len(text_tokens)
         src_tokens = torch.full(
@@ -206,11 +215,7 @@ class Dia:
             dtype=torch.long,
             device=self.device,
         )
-        src_tokens[0, :current_len] = torch.tensor(
-            text_tokens[:max_len],
-            dtype=torch.long,
-            device=self.device,
-        )
+        src_tokens[0, :current_len] = text_tokens
         return src_tokens
 
     def _prepare_audio_prompt(self, audio_prompt: torch.Tensor | None) -> tuple[torch.Tensor, int]:
@@ -257,8 +262,8 @@ class Dia:
 
         return prefill, prefill_step
 
-    def _prepare_generation(self, text: str, audio_prompt: str | torch.Tensor | None, verbose: bool):
-        enc_input_cond = self._prepare_text_input(text)
+    def _prepare_generation(self, text_tokens: torch.Tensor, audio_prompt: str | torch.Tensor | None):
+        enc_input_cond = self._pad_text_input(text_tokens)
         enc_input_uncond = torch.zeros_like(enc_input_cond)
         enc_input = torch.cat([enc_input_uncond, enc_input_cond], dim=0)
 
@@ -266,8 +271,6 @@ class Dia:
             audio_prompt = self.load_audio(audio_prompt)
         prefill, prefill_step = self._prepare_audio_prompt(audio_prompt)
 
-        if verbose:
-            print("generate: data loaded")
 
         enc_state = EncoderInferenceState.new(self.config, enc_input_cond)
         encoder_out = self.model.encoder(enc_input, enc_state)
@@ -400,10 +403,12 @@ class Dia:
 
         if use_torch_compile and not hasattr(self, "_compiled"):
             # Compilation can take about a minute.
-            self._prepare_generation = torch.compile(self._prepare_generation, dynamic=True)
+            self._prepare_generation = torch.compile(self._prepare_generation, dynamic=True, fullgraph=True)
             self._decoder_step = torch.compile(self._decoder_step, fullgraph=True, mode="max-autotune")
             self._compiled = True
-        dec_state, dec_output = self._prepare_generation(text, audio_prompt, verbose)
+
+        text_tokens = self._encode_text(text)
+        dec_state, dec_output = self._prepare_generation(text_tokens, audio_prompt)
         dec_step = dec_output.prefill_step - 1
         current_idx = torch.tensor([dec_step], device=self.device)
 

--- a/dia/model.py
+++ b/dia/model.py
@@ -271,7 +271,6 @@ class Dia:
             audio_prompt = self.load_audio(audio_prompt)
         prefill, prefill_step = self._prepare_audio_prompt(audio_prompt)
 
-
         enc_state = EncoderInferenceState.new(self.config, enc_input_cond)
         encoder_out = self.model.encoder(enc_input, enc_state)
 

--- a/dia/model.py
+++ b/dia/model.py
@@ -407,8 +407,7 @@ class Dia:
             self._decoder_step = torch.compile(self._decoder_step, fullgraph=True, mode="max-autotune")
             self._compiled = True
 
-        text_tokens = self._encode_text(text)
-        dec_state, dec_output = self._prepare_generation(text_tokens, audio_prompt)
+        dec_state, dec_output = self._prepare_generation(self._encode_text(text), audio_prompt)
         dec_step = dec_output.prefill_step - 1
         current_idx = torch.tensor([dec_step], device=self.device)
 

--- a/example/benchmark.py
+++ b/example/benchmark.py
@@ -4,6 +4,7 @@ import torch
 
 from dia.model import Dia
 
+
 torch._inductor.config.coordinate_descent_tuning = True
 torch._inductor.config.triton.unique_kernel_names = True
 torch._inductor.config.fx_graph_cache = True

--- a/example/benchmark.py
+++ b/example/benchmark.py
@@ -4,7 +4,6 @@ import torch
 
 from dia.model import Dia
 
-
 torch._inductor.config.coordinate_descent_tuning = True
 torch._inductor.config.triton.unique_kernel_names = True
 torch._inductor.config.fx_graph_cache = True
@@ -29,9 +28,11 @@ test_cases = [
 # Wram up
 for _ in range(2):
     text = choice(test_cases)
+    output = model.generate(text, audio_prompt="./example_prompt.mp3", use_torch_compile=True, verbose=True)
     output = model.generate(text, use_torch_compile=True, verbose=True)
 
 # Benchmark
 for _ in range(10):
     text = choice(test_cases)
     output = model.generate(text, use_torch_compile=True, verbose=True)
+    output = model.generate(text, audio_prompt="./example_prompt.mp3", use_torch_compile=True, verbose=True)


### PR DESCRIPTION
The python builtin functions `bytes.replace` and `print` cause graph breaks and can cause recompilation. They also prevent the use of `fullgraph=True`. The byte encoding has been moved out of the compilation, and the print has been removed.

Fixing these graph breaks reduces the number of recompilations (although recompilation of `_prepare_generation` seems pretty fast anyway). It very much cleans up the pytorch debug logs seen in `example/benchmark.py`.

Perf considerations: minimal with regards to tokens/s, but reduces number of recompilations.

Including resulting log from `python ./example/benchmark.py &> log.txt` below.

---
```text
/home/jakub/GitHub/dia/.venv/lib/python3.12/site-packages/torch/nn/utils/weight_norm.py:143: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.
  WeightNorm.apply(module, name, dim)
generate: starting generation loop
generate: by using use_torch_compile=True, the first step would take long
generate step 86: speed=14.285 tokens/s, realtime factor=0.166x
generate step 172: speed=235.826 tokens/s, realtime factor=2.742x
generate step 258: speed=235.483 tokens/s, realtime factor=2.738x
generate step 344: speed=235.368 tokens/s, realtime factor=2.737x
generate step 430: speed=235.776 tokens/s, realtime factor=2.742x
generate step 516: speed=235.297 tokens/s, realtime factor=2.736x
generate step 602: speed=235.772 tokens/s, realtime factor=2.742x
generate step 688: speed=235.499 tokens/s, realtime factor=2.738x
generate: total step=733, total duration=21.035s
generate: starting generation loop
generate: by using use_torch_compile=True, the first step would take long
generate step 86: speed=167.737 tokens/s, realtime factor=1.950x
generate step 172: speed=235.578 tokens/s, realtime factor=2.739x
generate step 258: speed=235.389 tokens/s, realtime factor=2.737x
generate step 344: speed=235.526 tokens/s, realtime factor=2.739x
generate step 430: speed=235.742 tokens/s, realtime factor=2.741x
generate: total step=455, total duration=2.099s
generate: starting generation loop
generate: by using use_torch_compile=True, the first step would take long
generate step 86: speed=169.792 tokens/s, realtime factor=1.974x
generate step 172: speed=235.212 tokens/s, realtime factor=2.735x
generate step 258: speed=235.603 tokens/s, realtime factor=2.740x
generate step 344: speed=235.328 tokens/s, realtime factor=2.736x
generate step 430: speed=235.137 tokens/s, realtime factor=2.734x
generate: total step=494, total duration=2.260s
generate: starting generation loop
generate: by using use_torch_compile=True, the first step would take long
generate step 86: speed=168.297 tokens/s, realtime factor=1.957x
generate step 172: speed=235.300 tokens/s, realtime factor=2.736x
generate step 258: speed=235.592 tokens/s, realtime factor=2.739x
generate step 344: speed=235.273 tokens/s, realtime factor=2.736x
generate step 430: speed=235.186 tokens/s, realtime factor=2.735x
generate: total step=455, total duration=2.099s
generate: starting generation loop
generate: by using use_torch_compile=True, the first step would take long
generate step 86: speed=168.352 tokens/s, realtime factor=1.958x
generate step 172: speed=235.577 tokens/s, realtime factor=2.739x
generate step 258: speed=235.211 tokens/s, realtime factor=2.735x
generate step 344: speed=235.596 tokens/s, realtime factor=2.739x
generate step 430: speed=235.256 tokens/s, realtime factor=2.736x
generate step 516: speed=235.104 tokens/s, realtime factor=2.734x
generate step 602: speed=235.568 tokens/s, realtime factor=2.739x
generate step 688: speed=235.272 tokens/s, realtime factor=2.736x
generate step 774: speed=235.250 tokens/s, realtime factor=2.735x
generate: total step=808, total duration=3.599s
generate: starting generation loop
generate: by using use_torch_compile=True, the first step would take long
generate step 86: speed=163.421 tokens/s, realtime factor=1.900x
generate step 172: speed=235.329 tokens/s, realtime factor=2.736x
generate step 258: speed=234.877 tokens/s, realtime factor=2.731x
generate step 344: speed=234.917 tokens/s, realtime factor=2.732x
generate step 430: speed=235.541 tokens/s, realtime factor=2.739x
generate step 516: speed=235.142 tokens/s, realtime factor=2.734x
generate step 602: speed=235.267 tokens/s, realtime factor=2.736x
generate step 688: speed=234.497 tokens/s, realtime factor=2.727x
generate: total step=767, total duration=3.444s
generate: starting generation loop
generate: by using use_torch_compile=True, the first step would take long
generate step 86: speed=165.655 tokens/s, realtime factor=1.926x
generate step 172: speed=235.518 tokens/s, realtime factor=2.739x
generate step 258: speed=234.929 tokens/s, realtime factor=2.732x
generate: total step=261, total duration=1.284s
generate: starting generation loop
generate: by using use_torch_compile=True, the first step would take long
generate step 86: speed=168.763 tokens/s, realtime factor=1.962x
generate step 172: speed=235.456 tokens/s, realtime factor=2.738x
generate step 258: speed=234.739 tokens/s, realtime factor=2.730x
generate step 344: speed=235.083 tokens/s, realtime factor=2.734x
generate step 430: speed=235.226 tokens/s, realtime factor=2.735x
generate step 516: speed=234.976 tokens/s, realtime factor=2.732x
generate step 602: speed=235.361 tokens/s, realtime factor=2.737x
generate: total step=680, total duration=3.058s
generate: starting generation loop
generate: by using use_torch_compile=True, the first step would take long
generate step 86: speed=158.932 tokens/s, realtime factor=1.848x
generate step 172: speed=230.058 tokens/s, realtime factor=2.675x
generate step 258: speed=233.730 tokens/s, realtime factor=2.718x
generate step 344: speed=225.472 tokens/s, realtime factor=2.622x
generate step 430: speed=234.097 tokens/s, realtime factor=2.722x
generate step 516: speed=234.967 tokens/s, realtime factor=2.732x
generate step 602: speed=233.681 tokens/s, realtime factor=2.717x
generate step 688: speed=234.748 tokens/s, realtime factor=2.730x
generate: total step=723, total duration=3.303s
generate: starting generation loop
generate: by using use_torch_compile=True, the first step would take long
generate step 86: speed=161.122 tokens/s, realtime factor=1.874x
generate step 172: speed=227.438 tokens/s, realtime factor=2.645x
generate step 258: speed=226.294 tokens/s, realtime factor=2.631x
generate step 344: speed=226.612 tokens/s, realtime factor=2.635x
generate step 430: speed=228.207 tokens/s, realtime factor=2.654x
generate step 516: speed=227.987 tokens/s, realtime factor=2.651x
generate step 602: speed=222.414 tokens/s, realtime factor=2.586x
generate step 688: speed=222.335 tokens/s, realtime factor=2.585x
generate: total step=731, total duration=3.410s
generate: starting generation loop
generate: by using use_torch_compile=True, the first step would take long
generate step 86: speed=162.408 tokens/s, realtime factor=1.888x
generate step 172: speed=234.198 tokens/s, realtime factor=2.723x
generate step 258: speed=228.853 tokens/s, realtime factor=2.661x
generate step 344: speed=226.538 tokens/s, realtime factor=2.634x
generate step 430: speed=227.335 tokens/s, realtime factor=2.643x
generate step 516: speed=229.170 tokens/s, realtime factor=2.665x
generate step 602: speed=234.565 tokens/s, realtime factor=2.727x
generate step 688: speed=231.660 tokens/s, realtime factor=2.694x
generate step 774: speed=231.303 tokens/s, realtime factor=2.690x
generate: total step=813, total duration=3.710s
generate: starting generation loop
generate: by using use_torch_compile=True, the first step would take long
generate step 86: speed=154.085 tokens/s, realtime factor=1.792x
generate step 172: speed=234.068 tokens/s, realtime factor=2.722x
generate step 258: speed=232.072 tokens/s, realtime factor=2.699x
generate step 344: speed=228.358 tokens/s, realtime factor=2.655x
generate step 430: speed=232.648 tokens/s, realtime factor=2.705x
generate step 516: speed=234.921 tokens/s, realtime factor=2.732x
generate step 602: speed=230.617 tokens/s, realtime factor=2.682x
generate step 688: speed=234.035 tokens/s, realtime factor=2.721x
generate step 774: speed=230.553 tokens/s, realtime factor=2.681x
generate: total step=781, total duration=3.573s
```