### PR TITLE
Disable attention mask when causal inference is used.

### DIFF
--- a/dia/layers.py
+++ b/dia/layers.py
@@ -252,7 +252,7 @@ class Attention(nn.Module):
             Xq_BxNxTxH,
             attn_k,
             attn_v,
-            attn_mask=attn_mask,
+            attn_mask=attn_mask if not is_causal else None,
             scale=1.0,
             enable_gqa=self.num_gqa_groups > 1,
             is_causal=is_causal,


### PR DESCRIPTION
Fixes #169. 

`RuntimeError: _scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True`