### PR TITLE
Enable Dia 1.6B Model to Run on Apple Silicon GPUs (MPS Backend) (#197)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,20 +95,20 @@ output = model.generate(text, use_torch_compile=True, verbose=True)
 model.save_audio("simple.mp3", output)
 ```
 
-If you're on Mac with Apple silicon, you can use the following code to make it work. It'll only run on CPU though.
+If you're on Mac with Apple Silicon, you can use the following code to make it work. For MPS to work `use_torch_compile` must be set to `False`. As that feature isn't supported yet.
 
 ```python
-from dia.model import Dia
 import torch
 
-device = torch.device("cpu")
+from dia.model import Dia
 
-# Pass the device parameter directly when loading
-model = Dia.from_pretrained(
-    "nari-labs/Dia-1.6B",
-    compute_dtype="float32",
-    device=device
-)
+
+# Select device: MPS if available, else CPU
+device = torch.device("mps") if torch.backends.mps.is_available() else torch.device("cpu")
+print(f"Using device: {device}")
+
+# Load model
+model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float32", device=device)
 
 text = "[S1] Dia is an open weights text to dialogue model. [S2] You get full control over scripts and voices. [S1] Wow. Amazing. (laughs) [S2] Try it now on Git hub or Hugging Face."
 

--- a/dia/layers.py
+++ b/dia/layers.py
@@ -139,7 +139,7 @@ def custom_scaled_dot_product_attention(
 ) -> torch.Tensor:
     """
     Custom scaled dot-product attention with GQA support for MPS compatibility.
-    
+
     Args:
         query: (B, N_q, T, H) - Query tensor, N_q = num_query_heads
         key: (B, N_kv, S, H) - Key tensor, N_kv = num_kv_heads
@@ -148,7 +148,7 @@ def custom_scaled_dot_product_attention(
         scale: Scaling factor for attention scores
         is_causal: If True, apply causal masking
         num_gqa_groups: Number of query groups per KV head (N_q / N_kv)
-    
+
     Returns:
         output: (B, N_q, T, H) - Attention output
     """

--- a/dia/layers.py
+++ b/dia/layers.py
@@ -128,6 +128,57 @@ class RotaryEmbedding(nn.Module):
         second_part = second_half * cos + first_half * sin
         return torch.cat((first_part.to(self.compute_dtype), second_part.to(self.compute_dtype)), dim=-1)
 
+def custom_scaled_dot_product_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_mask: torch.Tensor | None = None,
+    scale: float = 1.0,
+    is_causal: bool = False,
+    num_gqa_groups: int = 1,
+) -> torch.Tensor:
+    """
+    Custom scaled dot-product attention with GQA support for MPS compatibility.
+    
+    Args:
+        query: (B, N_q, T, H) - Query tensor, N_q = num_query_heads
+        key: (B, N_kv, S, H) - Key tensor, N_kv = num_kv_heads
+        value: (B, N_kv, S, H) - Value tensor
+        attn_mask: (B, 1, T, S) - Attention mask, optional
+        scale: Scaling factor for attention scores
+        is_causal: If True, apply causal masking
+        num_gqa_groups: Number of query groups per KV head (N_q / N_kv)
+    
+    Returns:
+        output: (B, N_q, T, H) - Attention output
+    """
+    B, N_q, T, H = query.shape
+    _, N_kv, S, _ = key.shape
+    
+    # For GQA, repeat key and value tensors to match query heads
+    if num_gqa_groups > 1:
+        key = key.repeat_interleave(num_gqa_groups, dim=1)    # (B, N_q, S, H)
+        value = value.repeat_interleave(num_gqa_groups, dim=1)  # (B, N_q, S, H)
+    
+    # Compute attention scores: (B, N_q, T, H) @ (B, N_q, H, S) -> (B, N_q, T, S)
+    scores = torch.matmul(query, key.transpose(-1, -2)) * scale
+    
+    # Apply causal mask if needed
+    if is_causal:
+        causal_mask = torch.tril(torch.ones(T, S, dtype=torch.bool, device=query.device))
+        scores = scores.masked_fill(~causal_mask, float('-inf'))
+    
+    # Apply attention mask if provided
+    if attn_mask is not None:
+        scores = scores.masked_fill(~attn_mask, float('-inf'))
+    
+    # Softmax over the last dimension (S)
+    attn_weights = F.softmax(scores, dim=-1)
+    
+    # Compute output: (B, N_q, T, S) @ (B, N_q, S, H) -> (B, N_q, T, H)
+    output = torch.matmul(attn_weights, value)
+    
+    return output
 
 class Attention(nn.Module):
     """Attention using DenseGeneral."""
@@ -248,15 +299,15 @@ class Attention(nn.Module):
             else:
                 attn_k, attn_v = cache.update(Xk_BxKxSxH, Xv_BxKxSxH, current_idx)
 
-        attn_output = F.scaled_dot_product_attention(
-            Xq_BxNxTxH,
-            attn_k,
-            attn_v,
-            attn_mask=attn_mask if not is_causal else None,
-            scale=1.0,
-            enable_gqa=self.num_gqa_groups > 1,
-            is_causal=is_causal,
-        )
+        attn_output = custom_scaled_dot_product_attention(
+                    query=Xq_BxNxTxH,
+                    key=attn_k,
+                    value=attn_v,
+                    attn_mask=attn_mask if not is_causal else None,
+                    scale=1.0,
+                    is_causal=is_causal,
+                    num_gqa_groups=self.num_gqa_groups,
+                )
 
         attn_output = attn_output.transpose(1, 2).contiguous()  # (B, T, N, H)
         output = self.o_proj(attn_output)

--- a/dia/layers.py
+++ b/dia/layers.py
@@ -301,15 +301,28 @@ class Attention(nn.Module):
             else:
                 attn_k, attn_v = cache.update(Xk_BxKxSxH, Xv_BxKxSxH, current_idx)
 
-        attn_output = custom_scaled_dot_product_attention(
-            query=Xq_BxNxTxH,
-            key=attn_k,
-            value=attn_v,
-            attn_mask=attn_mask if not is_causal else None,
-            scale=1.0,
-            is_causal=is_causal,
-            num_gqa_groups=self.num_gqa_groups,
-        )
+        # Use custom attention for MPS backend, otherwise use optimized PyTorch function
+        is_mps = Xq.device.type == "mps" and torch.backends.mps.is_available()
+        if is_mps:
+            attn_output = custom_scaled_dot_product_attention(
+                query=Xq_BxNxTxH,
+                key=attn_k,
+                value=attn_v,
+                attn_mask=attn_mask if not is_causal else None,
+                scale=1.0,
+                is_causal=is_causal,
+                num_gqa_groups=self.num_gqa_groups,
+            )
+        else:
+            attn_output = F.scaled_dot_product_attention(
+                Xq_BxNxTxH,
+                attn_k,
+                attn_v,
+                attn_mask=attn_mask if not is_causal else None,
+                scale=1.0,
+                enable_gqa=self.num_gqa_groups > 1,
+                is_causal=is_causal,
+            )
 
         attn_output = attn_output.transpose(1, 2).contiguous()  # (B, T, N, H)
         output = self.o_proj(attn_output)

--- a/example/simple-mac.py
+++ b/example/simple-mac.py
@@ -3,13 +3,18 @@ import torch
 from dia.model import Dia
 
 
-device = torch.device("cpu")
+# Select device: MPS if available, else CPU
+device = torch.device("mps") if torch.backends.mps.is_available() else torch.device("cpu")
+print(f"Using device: {device}")
 
-# Pass the device parameter directly when loading
+# Load model
 model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float32", device=device)
 
+# Input text
 text = "[S1] Dia is an open weights text to dialogue model. [S2] You get full control over scripts and voices. [S1] Wow. Amazing. (laughs) [S2] Try it now on Git hub or Hugging Face."
 
+# Generate audio
 output = model.generate(text, use_torch_compile=False, verbose=True)
 
+# Save output
 model.save_audio("simple.mp3", output)


### PR DESCRIPTION
**Fixes #197**

## Summary
This pull request resolves issue #197 by enabling the Dia 1.6B text-to-speech (TTS) model to run on Apple Silicon (M-series) GPUs using the Metal Performance Shaders (MPS) backend. The fix addresses a shape incompatibility in the attention mechanism that caused errors on MPS. A custom scaled dot-product attention function replaces the original implementation, ensuring compatibility and efficient execution on M-series Macs.

---

## Changes
The key modification is in `dia/layers.py`, where we replaced `F.scaled_dot_product_attention` with a custom implementation:
- **New Function**: `custom_scaled_dot_product_attention`
  - Explicitly repeats key and value tensors to match query heads for Grouped Query Attention (GQA).
  - Uses basic `torch.matmul` operations instead of fused attention functions.
- **Updated `Attention.forward` Method**: Calls the new function with GQA parameters, ensuring shape alignment.
- **Why This Change?**: MPS has stricter tensor shape requirements than CUDA or CPU. The custom function avoids broadcasting issues that triggered `mps_matmul` errors, while preserving GQA functionality.

---

## Why This Works
- **Shape Compatibility**: Manually aligning tensor shapes eliminates MPS-specific errors.
- **Simplified Operations**: Relies on well-supported `torch.matmul`, avoiding MPS limitations.
- **No Functional Loss**: Maintains the original attention logic for consistent model behavior.

---

## Testing and Validation
- Tested on an M-series Mac with MPS enabled.
- Confirmed successful audio generation without errors.
- Verified GPU usage via macOS Activity Monitor during inference. (uses 99% of the GPU through out the inference)

---

## Recommendations for Future Maintenance
- **Update PyTorch Regularly**: MPS support improves with releases, potentially reducing custom workarounds.
- **Debugging Tip**: Log tensor shapes in attention computations for troubleshooting.
- **GQA Option**: Temporarily set `num_query_heads = num_kv_heads` in the config for debugging (may affect performance).

---

## Conclusion
This pull request makes the Dia 1.6B model fully functional on Apple Silicon GPUs by fixing MPS compatibility issues detailed in #197. The changes in `dia/layers.py` provide a robust, user-friendly solution. Reviewers are encouraged to test on their hardware and share feedback.

After committing these changes, I've manually tested the model by running it on:
1. Nvidia A100 (80GB VRAM) - RunPod
2. MacBook Pro M3 Pro (Using both GPU and CPU)

Here are the results
### Using Nvidia A100 GPU (80GB VRAM)

```bash
generate: starting generation loop
generate: using use_torch_compile=True, the first step may be slow
generate step 86: speed=6.716 tokens/s, realtime factor=0.078x
generate step 172: speed=218.047 tokens/s, realtime factor=2.535x
generate step 258: speed=218.079 tokens/s, realtime factor=2.536x
generate step 344: speed=217.908 tokens/s, realtime factor=2.534x
generate step 430: speed=217.129 tokens/s, realtime factor=2.525x
generate step 516: speed=217.717 tokens/s, realtime factor=2.532x
generate step 602: speed=217.898 tokens/s, realtime factor=2.534x
generate step 688: speed=217.757 tokens/s, realtime factor=2.532x
generate: avg steps=707.0, total duration=41.200s
```

### Using MPS (MacBook Pro M3 Pro - 36 GB RAM)

```bash
generate: starting generation loop
generate step 86: speed=7.759 tokens/s, realtime factor=0.090x
generate step 172: speed=8.470 tokens/s, realtime factor=0.098x
generate step 258: speed=8.536 tokens/s, realtime factor=0.099x
generate step 344: speed=8.489 tokens/s, realtime factor=0.099x
generate step 430: speed=8.607 tokens/s, realtime factor=0.100x
generate step 516: speed=8.615 tokens/s, realtime factor=0.100x
generate step 602: speed=8.592 tokens/s, realtime factor=0.100x
generate step 688: speed=8.597 tokens/s, realtime factor=0.100x
generate: avg steps=747.0, total duration=91.026s
```

### Using CPU (MacBook Pro M3 Pro - 36 GB RAM)

```bash
generate: starting generation loop
generate step 86: speed=2.531 tokens/s, realtime factor=0.029x
generate step 172: speed=2.639 tokens/s, realtime factor=0.031x
generate step 258: speed=2.619 tokens/s, realtime factor=0.030x
generate step 344: speed=2.645 tokens/s, realtime factor=0.031x
generate step 430: speed=2.647 tokens/s, realtime factor=0.031x
generate step 516: speed=2.577 tokens/s, realtime factor=0.030x
generate step 602: speed=2.603 tokens/s, realtime factor=0.030x
generate step 688: speed=2.626 tokens/s, realtime factor=0.031x
generate: avg steps=724.0, total duration=284.937s
```
