### PR TITLE
Simpler macOS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,20 +98,15 @@ model.save_audio("simple.mp3", output)
 If you're on Mac with Apple Silicon, you can use the following code to make it work. For MPS to work `use_torch_compile` must be set to `False`. As that feature isn't supported yet.
 
 ```python
-import torch
-
 from dia.model import Dia
 
 
-# Select device: MPS if available, else CPU
-device = torch.device("mps") if torch.backends.mps.is_available() else torch.device("cpu")
-print(f"Using device: {device}")
-
-# Load model
-model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float32", device=device)
+model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float16")
 
 text = "[S1] Dia is an open weights text to dialogue model. [S2] You get full control over scripts and voices. [S1] Wow. Amazing. (laughs) [S2] Try it now on Git hub or Hugging Face."
 
+# It is important to set the `use_torch_compile` argument to `False` when using Dia on MacOS.
+# This is because the `torch.compile` function is not supported on MacOS.
 output = model.generate(text, use_torch_compile=False, verbose=True)
 
 model.save_audio("simple.mp3", output)

--- a/example/simple-mac.py
+++ b/example/simple-mac.py
@@ -1,20 +1,12 @@
-import torch
-
 from dia.model import Dia
 
 
-# Select device: MPS if available, else CPU
-device = torch.device("mps") if torch.backends.mps.is_available() else torch.device("cpu")
-print(f"Using device: {device}")
+model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float16")
 
-# Load model
-model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float32", device=device)
-
-# Input text
 text = "[S1] Dia is an open weights text to dialogue model. [S2] You get full control over scripts and voices. [S1] Wow. Amazing. (laughs) [S2] Try it now on Git hub or Hugging Face."
 
-# Generate audio
+# It is important to set the `use_torch_compile` argument to `False` when using Dia on MacOS.
+# This is because the `torch.compile` function is not supported on MacOS.
 output = model.generate(text, use_torch_compile=False, verbose=True)
 
-# Save output
 model.save_audio("simple.mp3", output)


### PR DESCRIPTION
Since the code has been changed to detect the backend even for MPS automatically, we don't need to specify it separately. The only thing that is important for it to work is to set `use_torch_compile` to `False` as PyTorch doesn't support it on macOS.