### PR TITLE
Update compute_dtype to float32 for better CPU performance

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,22 +37,15 @@ print(f"Using device: {device}")
 # Load Nari model and config
 print("Loading Nari model...")
 try:
-    if device.type == "cpu":
-        # CPU performs better on float32
-        print(f"Using device: {device}, attempting to load model with float32")
-        model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float32", device=device)
-    elif device.type == "mps":
-        # MPS (Apple Silicon) prefers float32 due to poor float16 support
-        print(f"Using device: {device}, attempting to load model with float32")
-        model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float32", device=device)
-    elif device.type == "cuda":
-        # CUDA (NVIDIA) benefits from float16
-        print(f"Using device: {device}, attempting to load model with float16")
-        model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float16", device=device)
-    else:
-        # Fallback
-        print(f"Unknown device type '{device.type}', defaulting to float16")
-        model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float16", device=device)
+    dtype_map = {
+        "cpu": "float32",
+        "mps": "float32",  # Apple M series – better with float32
+        "cuda": "float16",  # NVIDIA – better with float16
+    }
+
+    dtype = dtype_map.get(device.type, "float16")
+    print(f"Using device: {device}, attempting to load model with {dtype}")
+    model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype=dtype, device=device)
 except Exception as e:
     print(f"Error loading Nari model: {e}")
     raise

--- a/app.py
+++ b/app.py
@@ -37,8 +37,19 @@ print(f"Using device: {device}")
 # Load Nari model and config
 print("Loading Nari model...")
 try:
-    # Use the function from inference.py
-    model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float16", device=device)
+    if device.type == "cpu":
+        # CPU performs better on float32
+        model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float32", device=device)
+    elif device.type == "mps":
+        # MPS (Apple Silicon) prefers float32 due to poor float16 support
+        model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float32", device=device)
+    elif device.type == "cuda":
+        # CUDA (NVIDIA) benefits from float16
+        model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float16", device=device)
+    else:
+        # Fallback
+        print(f"Unknown device type '{device.type}', defaulting to float32")
+        model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float32", device=device)
 except Exception as e:
     print(f"Error loading Nari model: {e}")
     raise

--- a/app.py
+++ b/app.py
@@ -39,12 +39,15 @@ print("Loading Nari model...")
 try:
     if device.type == "cpu":
         # CPU performs better on float32
+        print(f"Using device: {device}, attempting to load model with float32")
         model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float32", device=device)
     elif device.type == "mps":
         # MPS (Apple Silicon) prefers float32 due to poor float16 support
+        print(f"Using device: {device}, attempting to load model with float32")
         model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float32", device=device)
     elif device.type == "cuda":
         # CUDA (NVIDIA) benefits from float16
+        print(f"Using device: {device}, attempting to load model with float16")
         model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float16", device=device)
     else:
         # Fallback

--- a/app.py
+++ b/app.py
@@ -51,8 +51,8 @@ try:
         model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float16", device=device)
     else:
         # Fallback
-        print(f"Unknown device type '{device.type}', defaulting to float32")
-        model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float32", device=device)
+        print(f"Unknown device type '{device.type}', defaulting to float16")
+        model = Dia.from_pretrained("nari-labs/Dia-1.6B", compute_dtype="float16", device=device)
 except Exception as e:
     print(f"Error loading Nari model: {e}")
     raise

--- a/example/simple-cpu.py
+++ b/example/simple-cpu.py
@@ -9,8 +9,8 @@ print(f"Using device: {device}")
 
 # Load model
 model = Dia.from_pretrained(
-    "nari-labs/Dia-1.6B", compute_dtype="float16", device=device
-)  # If you're on a Mac with M1/M2, use "float32" in compute_dtype
+    "nari-labs/Dia-1.6B", compute_dtype="float32", device=device
+)  # Float32 works better than float16 on CPU - you can also test with float16
 
 text = "[S1] Dia is an open weights text to dialogue model. [S2] You get full control over scripts and voices. [S1] Wow. Amazing. (laughs) [S2] Try it now on Git hub or Hugging Face."
 


### PR DESCRIPTION
Improves on Issue #210 

As the title suggests, I've changed the CPU's example from using float16 to float32 as it seems to perform a lot better in terms of speed on CPU, as suggested by users in the issue's comments.