### PR TITLE
Perf: Some small enhancements

### DIFF
--- a/dia/layers.py
+++ b/dia/layers.py
@@ -431,8 +431,8 @@ class SelfAttention(nn.Module):
         self.qkv = FusedQKV(
             self.kv_embed_dim,
             (
-                self.num_query_heads * self.head_dim + 
-                2 * (self.num_kv_heads * self.head_dim)
+                self.num_query_heads * self.head_dim
+                + 2 * (self.num_kv_heads * self.head_dim)
             ),
             bias=False,
             num_q_heads=self.num_query_heads,

--- a/dia/layers.py
+++ b/dia/layers.py
@@ -430,15 +430,12 @@ class SelfAttention(nn.Module):
 
         self.qkv = FusedQKV(
             self.kv_embed_dim,
-            (
-                self.num_query_heads * self.head_dim
-                + 2 * (self.num_kv_heads * self.head_dim)
-            ),
+            (self.num_query_heads * self.head_dim + 2 * (self.num_kv_heads * self.head_dim)),
             bias=False,
             num_q_heads=self.num_query_heads,
             q_head_dim=self.head_dim,
             num_kv_heads=self.num_kv_heads,
-            kv_head_dim=self.head_dim
+            kv_head_dim=self.head_dim,
         )
         self.qkv.linear.weight.data = torch.cat([q_proj_weight, k_proj_weight, v_proj_weight], dim=0)
 

--- a/dia/layers.py
+++ b/dia/layers.py
@@ -128,6 +128,12 @@ class RotaryEmbedding(nn.Module):
         second_part = second_half * cos + first_half * sin
         return torch.cat((first_part.to(self.compute_dtype), second_part.to(self.compute_dtype)), dim=-1)
 
+    def apply_rope(self, inputs: torch.Tensor, sin: torch.Tensor, cos: torch.Tensor):
+        first_half, second_half = torch.chunk(inputs.to(torch.float32), 2, dim=-1)
+        first_part = first_half * cos - second_half * sin
+        second_part = second_half * cos + first_half * sin
+        return torch.cat((first_part.to(self.compute_dtype), second_part.to(self.compute_dtype)), dim=-1)
+
 
 def custom_scaled_dot_product_attention(
     query: torch.Tensor,
@@ -182,8 +188,8 @@ def custom_scaled_dot_product_attention(
     return output
 
 
-class Attention(nn.Module):
-    """Attention using DenseGeneral."""
+class CrossAttention(nn.Module):
+    """Cross-Attention using DenseGeneral."""
 
     def __init__(
         self,
@@ -194,14 +200,12 @@ class Attention(nn.Module):
         num_kv_heads: int,
         head_dim: int,
         compute_dtype: torch.dtype,
-        is_cross_attn: bool = False,
         out_embed_dim: int | None = None,
     ):
         super().__init__()
         self.num_query_heads = num_query_heads
         self.num_kv_heads = num_kv_heads
         self.head_dim = head_dim
-        self.is_cross_attn = is_cross_attn
         self.output_dim = out_embed_dim if out_embed_dim is not None else q_embed_dim
         self.projected_query_dim = num_query_heads * head_dim
         if num_query_heads % num_kv_heads != 0:
@@ -245,7 +249,205 @@ class Attention(nn.Module):
     def forward(
         self,
         Xq: torch.Tensor,  # (B, T, D) T = 1 in AR generation
-        Xkv: torch.Tensor,  # (B, S, E) S = 1 in AR generation
+        q_positions: torch.Tensor,  # (B, T)
+        kv_positions: torch.Tensor | None = None,  # (B, S)
+        attn_mask: torch.Tensor | None = None,  # None in Decoder Self Attention, Valid mask in Others
+        cache: KVCache | None = None,  # None in Encoder, KVCache in Decoder
+        is_causal: bool = False,
+    ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor] | None]:
+        """
+        Performs attention calculation with optional KV caching.
+
+        Args:
+            Xq: Query tensor (B, T, D). T=1 during single-step decoding.
+            Xkv: Key/Value source tensor (B, S, E). S=1 during single-step decoding for self-attn.
+            q_positions: Positions for queries (B, T).
+            kv_positions: Positions for keys/values (B, S). If None, uses q_positions.
+            attn_mask: Attention mask.
+            cache: KVCache.
+
+        Returns:
+            A tuple containing:
+            - output: The attention output tensor (B, T, output_dim).
+            - present_kv: The K/V state to be cached for the next step ((B, N, S_new, H), (B, N, S_new, H)). For self-attn, S_new = S_past + S. For cross-attn, S_new = S_kv.
+        """
+        if kv_positions is None:
+            kv_positions = q_positions
+        original_dtype = Xq.dtype
+
+        Xq_BxTxNxH = self.q_proj(Xq)
+        Xq_BxTxNxH = self.rotary_emb(Xq_BxTxNxH, position=q_positions)
+        Xq_BxNxTxH = Xq_BxTxNxH.transpose(1, 2)
+
+        attn_k: torch.Tensor | None = None
+        attn_v: torch.Tensor | None = None
+
+        attn_k, attn_v = cache.k, cache.v
+
+        # Use custom attention for MPS backend, otherwise use optimized PyTorch function
+        is_mps = Xq.device.type == "mps" and torch.backends.mps.is_available()
+        if is_mps:
+            attn_output = custom_scaled_dot_product_attention(
+                query=Xq_BxNxTxH,
+                key=attn_k,
+                value=attn_v,
+                attn_mask=attn_mask if not is_causal else None,
+                scale=1.0,
+                is_causal=is_causal,
+                num_gqa_groups=self.num_gqa_groups,
+            )
+        else:
+            attn_output = F.scaled_dot_product_attention(
+                Xq_BxNxTxH,
+                attn_k,
+                attn_v,
+                attn_mask=attn_mask if not is_causal else None,
+                scale=1.0,
+                enable_gqa=self.num_gqa_groups > 1,
+                is_causal=is_causal,
+            )
+
+        attn_output = attn_output.transpose(1, 2).contiguous()  # (B, T, N, H)
+        output = self.o_proj(attn_output)
+
+        return output.to(original_dtype)
+
+
+class FusedQKV(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = False,
+        num_q_heads: int = 1,
+        q_head_dim: int = 1,
+        num_kv_heads: int = 1,
+        kv_head_dim: int = 1,
+    ):
+        super().__init__()
+        self.num_q_heads = num_q_heads
+        self.q_head_dim = q_head_dim
+        self.num_kv_heads = num_kv_heads
+        self.kv_head_dim = kv_head_dim
+        self.q_output_dim = num_q_heads * q_head_dim
+        self.kv_output_dim = num_kv_heads * kv_head_dim
+        self.linear = nn.Linear(in_features, out_features, bias=bias)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        x = self.linear(inputs)
+
+        q, k, v = x.split([self.q_output_dim, self.kv_output_dim, self.kv_output_dim], dim=-1)
+
+        q = q.reshape(q.shape[:-1] + (self.num_q_heads, self.q_head_dim))
+        k = k.reshape(k.shape[:-1] + (self.num_kv_heads, self.kv_head_dim))
+        v = v.reshape(v.shape[:-1] + (self.num_kv_heads, self.kv_head_dim))
+
+        return q, k, v
+
+
+class SelfAttention(nn.Module):
+    """Attention using DenseGeneral."""
+
+    def __init__(
+        self,
+        config: DiaConfig,
+        q_embed_dim: int,
+        kv_embed_dim: int,
+        num_query_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        compute_dtype: torch.dtype,
+        is_cross_attn: bool = False,
+        out_embed_dim: int | None = None,
+    ):
+        super().__init__()
+        self.num_query_heads = num_query_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.is_cross_attn = is_cross_attn
+        self.output_dim = out_embed_dim if out_embed_dim is not None else q_embed_dim
+        self.projected_query_dim = num_query_heads * head_dim
+        if num_query_heads % num_kv_heads != 0:
+            raise ValueError(f"num_query_heads ({num_query_heads}) must be divisible by num_kv_heads ({num_kv_heads})")
+        self.num_gqa_groups = num_query_heads // num_kv_heads
+        self.kv_embed_dim = kv_embed_dim
+        self.q_embed_dim = q_embed_dim
+
+        # --- Projection Layers using DenseGeneral ---
+        self.q_proj = DenseGeneral(
+            in_shapes=(q_embed_dim,),
+            out_features=(num_query_heads, head_dim),
+            axis=(-1,),
+            weight_dtype=compute_dtype,
+        )
+        self.k_proj = DenseGeneral(
+            in_shapes=(kv_embed_dim,),
+            out_features=(num_kv_heads, head_dim),
+            axis=(-1,),
+            weight_dtype=compute_dtype,
+        )
+        self.v_proj = DenseGeneral(
+            in_shapes=(kv_embed_dim,),
+            out_features=(num_kv_heads, head_dim),
+            axis=(-1,),
+            weight_dtype=compute_dtype,
+        )
+        self.o_proj = DenseGeneral(
+            in_shapes=(num_query_heads, head_dim),
+            out_features=(self.output_dim,),
+            axis=(-2, -1),
+            weight_dtype=compute_dtype,
+        )
+
+        # --- Rotary Embedding ---
+        self.rotary_emb = RotaryEmbedding(
+            embedding_dims=self.head_dim,
+            min_timescale=config.model.rope_min_timescale,
+            max_timescale=config.model.rope_max_timescale,
+            dtype=compute_dtype,
+        )
+
+        self.is_fused_qkv = False
+
+    def get_linear_weight(self, dense: DenseGeneral):
+        W_dg = dense.weight.data
+
+        out_features = 1
+        input_features = 1
+        for dim in dense.out_features:
+            out_features *= dim
+        for dim in dense.in_shapes:
+            input_features *= dim
+
+        W_dg_reshaped_for_linear_T = W_dg.reshape(input_features, out_features)
+        linear_weight = W_dg_reshaped_for_linear_T.transpose(0, 1).contiguous()
+        return linear_weight
+
+    def patch_fused_qkv(self):
+        q_proj_weight = self.get_linear_weight(self.q_proj)
+        k_proj_weight = self.get_linear_weight(self.k_proj)
+        v_proj_weight = self.get_linear_weight(self.v_proj)
+
+        self.qkv = FusedQKV(
+            self.kv_embed_dim,
+            (
+                self.num_query_heads * self.head_dim + 
+                2 * (self.num_kv_heads * self.head_dim)
+            ),
+            bias=False,
+            num_q_heads=self.num_query_heads,
+            q_head_dim=self.head_dim,
+            num_kv_heads=self.num_kv_heads,
+            kv_head_dim=self.head_dim
+        )
+        self.qkv.linear.weight.data = torch.cat([q_proj_weight, k_proj_weight, v_proj_weight], dim=0)
+
+        # print(f"qkv.weight.shape: {self.qkv.linear.weight.shape}")
+        self.is_fused_qkv = True
+
+    def forward(
+        self,
+        X: torch.Tensor,  # (B, T, D) T = 1 in AR generation
         q_positions: torch.Tensor,  # (B, T)
         kv_positions: torch.Tensor | None = None,  # (B, S)
         attn_mask: torch.Tensor | None = None,  # None in Decoder Self Attention, Valid mask in Others
@@ -273,36 +475,43 @@ class Attention(nn.Module):
         """
         if kv_positions is None:
             kv_positions = q_positions
-        original_dtype = Xq.dtype
 
-        Xq_BxTxNxH = self.q_proj(Xq)
-        Xq_BxTxNxH = self.rotary_emb(Xq_BxTxNxH, position=q_positions)
+        original_dtype = X.dtype
+
+        if self.is_fused_qkv:
+            Xq_BxTxNxH, Xk_BxSxKxH, Xv_BxSxKxH = self.qkv(X)
+        else:
+            Xq_BxTxNxH = self.q_proj(X)
+            Xk_BxSxKxH = self.k_proj(X)
+            Xv_BxSxKxH = self.v_proj(X)
+
+        position = q_positions.unsqueeze(-1).unsqueeze(-1)
+        sinusoid_inp = position / self.rotary_emb.timescale
+        sin = torch.sin(sinusoid_inp)
+        cos = torch.cos(sinusoid_inp)
+
+        Xq_BxTxNxH = self.rotary_emb.apply_rope(Xq_BxTxNxH, sin, cos)
+        Xk_BxSxKxH = self.rotary_emb.apply_rope(Xk_BxSxKxH, sin, cos)
+
         Xq_BxNxTxH = Xq_BxTxNxH.transpose(1, 2)
 
         attn_k: torch.Tensor | None = None
         attn_v: torch.Tensor | None = None
 
-        if self.is_cross_attn:
-            attn_k, attn_v = cache.k, cache.v
+        Xk_BxKxSxH = Xk_BxSxKxH.transpose(1, 2)  # (B, K, S, H)
+        Xv_BxKxSxH = Xv_BxSxKxH.transpose(1, 2)  # (B, K, S, H)
+
+        if cache is None:
+            attn_k = Xk_BxKxSxH
+            attn_v = Xv_BxKxSxH
+        elif prefill:
+            attn_k, attn_v = Xk_BxKxSxH, Xv_BxKxSxH
+            cache.prefill(attn_k, attn_v)
         else:
-            Xk_BxSxKxH = self.k_proj(Xkv)  # (B, S, K, H)
-            Xv_BxSxKxH = self.v_proj(Xkv)  # (B, S, K, H)
-            Xk_BxSxKxH = self.rotary_emb(Xk_BxSxKxH, position=kv_positions)  # (B, S, K, H)
-
-            Xk_BxKxSxH = Xk_BxSxKxH.transpose(1, 2)  # (B, K, S, H)
-            Xv_BxKxSxH = Xv_BxSxKxH.transpose(1, 2)  # (B, K, S, H)
-
-            if cache is None:
-                attn_k = Xk_BxKxSxH
-                attn_v = Xv_BxKxSxH
-            elif prefill:
-                attn_k, attn_v = Xk_BxKxSxH, Xv_BxKxSxH
-                cache.prefill(attn_k, attn_v)
-            else:
-                attn_k, attn_v = cache.update(Xk_BxKxSxH, Xv_BxKxSxH, current_idx)
+            attn_k, attn_v = cache.update(Xk_BxKxSxH, Xv_BxKxSxH, current_idx)
 
         # Use custom attention for MPS backend, otherwise use optimized PyTorch function
-        is_mps = Xq.device.type == "mps" and torch.backends.mps.is_available()
+        is_mps = Xv_BxSxKxH.device.type == "mps" and torch.backends.mps.is_available()
         if is_mps:
             attn_output = custom_scaled_dot_product_attention(
                 query=Xq_BxNxTxH,
@@ -346,7 +555,7 @@ class EncoderLayer(nn.Module):
             eps=model_config.normalization_layer_epsilon,
             dtype=torch.float32,
         )
-        self.self_attention = Attention(
+        self.self_attention = SelfAttention(
             config,
             q_embed_dim=embed_dim,
             kv_embed_dim=embed_dim,
@@ -373,8 +582,7 @@ class EncoderLayer(nn.Module):
         x_norm = self.pre_sa_norm(x).to(self.compute_dtype)
 
         sa_out = self.self_attention(
-            Xq=x_norm,
-            Xkv=x_norm,
+            X=x_norm,
             q_positions=state.positions,
             kv_positions=state.positions,
             attn_mask=state.attn_mask,
@@ -456,7 +664,7 @@ class DecoderLayer(nn.Module):
         )
 
         # Self-Attention (GQA) with Causal Masking
-        self.self_attention = Attention(
+        self.self_attention = SelfAttention(
             config,
             q_embed_dim=dec_embed_dim,
             kv_embed_dim=dec_embed_dim,
@@ -468,7 +676,7 @@ class DecoderLayer(nn.Module):
             out_embed_dim=dec_embed_dim,
         )
         # Cross-Attention (MHA)
-        self.cross_attention = Attention(
+        self.cross_attention = CrossAttention(
             config=config,
             q_embed_dim=dec_embed_dim,
             kv_embed_dim=enc_embed_dim,  # Note kv_embed_dim
@@ -476,7 +684,6 @@ class DecoderLayer(nn.Module):
             num_kv_heads=dec_config.cross_query_heads,
             head_dim=dec_config.cross_head_dim,
             compute_dtype=compute_dtype,
-            is_cross_attn=True,
             out_embed_dim=dec_embed_dim,
         )
         # MLP
@@ -501,8 +708,7 @@ class DecoderLayer(nn.Module):
         self_attn_mask = state.casual_attn_mask[None, None, current_idx]
 
         sa_out = self.self_attention(
-            Xq=x_norm,  # (2, 1, D)
-            Xkv=x_norm,  # (2, 1, D)
+            X=x_norm,  # (2, 1, D)
             q_positions=state.dec_positions,  # (2, 1)
             kv_positions=state.dec_positions,  # (2, 1)
             attn_mask=self_attn_mask,
@@ -518,11 +724,9 @@ class DecoderLayer(nn.Module):
         x_norm = self.pre_ca_norm(x).to(self.compute_dtype)
         ca_out = self.cross_attention(
             Xq=x_norm,
-            Xkv=state.enc_out,
             q_positions=state.dec_positions,
             kv_positions=state.enc_positions,
             cache=cross_attn_cache,
-            current_idx=current_idx,
         )
         x = residual + ca_out
 

--- a/dia/model.py
+++ b/dia/model.py
@@ -339,6 +339,7 @@ class Dia:
         self,
         text: torch.Tensor,
         audio_prompts: list[torch.Tensor | None],
+        max_tokens: int | None = None,
     ):
         """Initializes the model state for generation.
 
@@ -371,7 +372,7 @@ class Dia:
             encoder_out, enc_state.positions, enc_state.padding_mask
         )
         dec_state = DecoderInferenceState.new(
-            self.config, enc_state, encoder_out, dec_cross_attn_cache, self.compute_dtype
+            self.config, enc_state, encoder_out, dec_cross_attn_cache, self.compute_dtype, max_generation_length=max_tokens
         )
         prefill, prefill_steps = self._prepare_audio_prompt(audio_prompts)
 
@@ -663,7 +664,7 @@ class Dia:
             text = [self._encode_text(text)]
         text = self._pad_text_input(text)
 
-        dec_state, dec_output = self._prepare_generation(text, audio_prompt)
+        dec_state, dec_output = self._prepare_generation(text, audio_prompt, max_tokens=max_tokens)
         dec_step = min(dec_output.prefill_steps) - 1
         current_idx = torch.tensor([dec_step], device=self.device)
 

--- a/dia/model.py
+++ b/dia/model.py
@@ -372,7 +372,12 @@ class Dia:
             encoder_out, enc_state.positions, enc_state.padding_mask
         )
         dec_state = DecoderInferenceState.new(
-            self.config, enc_state, encoder_out, dec_cross_attn_cache, self.compute_dtype, max_generation_length=max_tokens
+            self.config,
+            enc_state,
+            encoder_out,
+            dec_cross_attn_cache,
+            self.compute_dtype,
+            max_generation_length=max_tokens,
         )
         prefill, prefill_steps = self._prepare_audio_prompt(audio_prompts)
 

--- a/dia/state.py
+++ b/dia/state.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 import torch
 
@@ -135,10 +136,11 @@ class DecoderInferenceState:
         enc_out: torch.Tensor,
         dec_cross_attn_cache: list[KVCache],
         compute_dtype: torch.dtype,
+        max_generation_length: Optional[int] = None,
     ) -> "DecoderInferenceState":
         """Creates DecoderInferenceParams from DiaConfig and a device."""
         device = enc_out.device
-        max_audio_len = config.data.audio_length
+        max_audio_len = max_generation_length or config.data.audio_length
         batch_size = enc_out.shape[0] // 2
 
         dec_positions = torch.full((2 * batch_size, 1), fill_value=0, dtype=torch.int32, device=device)


### PR DESCRIPTION
Did in PR:
1. Split `Attention` to 2 class: `SelfAttention` and `CrossAttention` for further optimization
2. Add Fused QKV: Operate q_proj, k_proj, v_proj in one layer
3. Enhance Rope: reuse cos, sin for self attention
3. Add adjust KV cache max_length == max_token_lengths instead of always set to model's max length => less VRAM use, slightly faster


Test scripts:
```py
from random import choice

import torch

from dia.model import Dia


torch._inductor.config.coordinate_descent_tuning = True
torch._inductor.config.triton.unique_kernel_names = True
torch._inductor.config.fx_graph_cache = True

# debugging
torch._logging.set_logs(graph_breaks=True, recompiles=True)

model_name = "nari-labs/Dia-1.6B"
compute_dtype = "float16"

model = Dia.from_pretrained(model_name, compute_dtype=compute_dtype)


for idx in range(len(model.model.decoder.layers)):
    layer = model.model.decoder.layers[idx]
    layer.self_attention.patch_fused_qkv()


test_cases = [
    "[S1] Dia is an open weights text to dialogue model.",
    "[S1] Dia is an open weights text to dialogue model. [S2] You get full control over scripts and voices. [S1] Wow. Amazing. (laughs) [S2] Try it now on Git hub or Hugging Face.",
    "[S1] torch.compile is a new feature in PyTorch that allows you to compile your model with a single line of code.",
    "[S1] torch.compile is a new feature in PyTorch that allows you to compile your model with a single line of code. [S2] It is a new feature in PyTorch that allows you to compile your model with a single line of code.",
]


use_torch_compile = True

MAX_TOKENS = 86*5

# # # Wram up
for _ in range(2):
    text = choice(test_cases)
    output = model.generate(text, use_torch_compile=use_torch_compile, verbose=True, max_tokens=MAX_TOKENS)

text = choice(test_cases)

# Benchmark
for i in range(10):
    output = model.generate(text, use_torch_compile=use_torch_compile, verbose=True, max_tokens=MAX_TOKENS)
    text = choice(test_cases)

```

Result on A100 80Gb:
```
~216 token/s => ~232 token/s
```

Other room for speed-up:
- Upon analyzing the flame graph, a significant 20% gap has been identified in the token generation time. This gap occurs between the GPU launch (_decode_step) and the sampling phase (computing the next token and checking for ending conditions), indicating a potential area for optimization.

<img width="378" alt="Screenshot 2025-05-28 at 00 51 26" src="https://github.com/user-attachments/assets/ee8f9caf-dd7c-422c-bf48-bfa91811b2b9" />
<img width="403" alt="Screenshot 2025-05-28 at 00 51 18" src="https://github.com/user-attachments/assets/2e5860f7-0a9b-4030-a98d-993eddcf383f" />




