### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ cd dia
 python -m venv .venv && source .venv/bin/activate
 # On Windows: python -m venv .venv; ./.venv/Scripts/activate
 
+# Optional: To allow GPU utilization, we must specify installation of CUDA-enabled wheels of torch libraries
+# pip install torch==2.6.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu126
+
 # Install dia
 pip install -e .
 ```
@@ -107,13 +110,9 @@ Or you can install without cloning.
 ```bash
 # Install directly from GitHub
 pip install git+https://github.com/nari-labs/dia.git
-```
 
-To enable allowing GPU utilization, we need to install CUDA-enabled wheels of torch libraries too:
-
-```bash
-# Reinstallation of torch libraries
-pip install torch==2.6.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu126
+# Optional: To allow GPU utilization, we must force installation of CUDA-enabled wheels of torch libraries
+# pip install torch==2.6.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu126 --force-reinstall
 ```
 
 Now, run some examples.


### PR DESCRIPTION
- Fixed the remaining HuggingFace Spaces text hyperlink that was missed in #255 (which only fixed the SVG image link).

- Added streamlined installation instructions for CUDA-enabled torch libraries for pip users (#16). The project's pyproject.toml configures GPU support automatically for uv users, but pip users get CPU-only PyTorch by default.