### PR TITLE
Fix Link for ZeroGPU Space for Dia

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To accelerate research, we are providing access to pretrained model checkpoints 
 
 We also provide a [demo page](https://yummy-fir-7a4.notion.site/dia) comparing our model to [ElevenLabs Studio](https://elevenlabs.io/studio) and [Sesame CSM-1B](https://github.com/SesameAILabs/csm).
 
-- We have a ZeroGPU Space running! Try it now [here](https://huggingface.co/spaces/nari-labs/Dia-1.6B-0626). Thanks to the HF team for the support :)
+- We have a ZeroGPU Space running! Try it now [here](https://huggingface.co/spaces/nari-labs/Dia-1.6B). Thanks to the HF team for the support :)
 - Join our [discord server](https://discord.gg/bJq6vjRRKv) for community support and access to new features.
 - Play with a larger version of Dia: generate fun conversations, remix content, and share with friends. 🔮 Join the [waitlist](https://tally.so/r/meokbo) for early access.
 


### PR DESCRIPTION
This PR updates the Nari Text-to-Speech link which previously pointed to an incorrect URL.